### PR TITLE
Update definition schema to allow non-synthesizable entities

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,13 +20,13 @@ so your PR will get merged faster, and you can start enjoying your shiny new ent
 We use the `domain`, `type` and `identifier` to assign each entity a Global Unique Identifier (GUID).
 - The `domain` must be a value matching `/[A-Z][A-Z0-9_]{2,7}/`. This field is mostly relevant internally for NR. 
 Use EXT by default, although we may advise to use a different value in some cases.                
-- The `type` must be a value matching `/[A-Z][A-Z0-9_]{2,19}/`. This field is meant to identify the type of entity. 
+- The `type` must be a value matching `/[A-Z][A-Z0-9_]{2,11}/`. This field is meant to identify the type of entity. 
 Some examples are APPLICATION, HOST or CONTAINER.  
 - The `identifier` must be assigned a parameter that is unique within the domain and type (e.g
 . cluster ID, host ID, etc). Keep in mind that the value has the following restrictions and that the
  entity will not be synthesized if the value extracted from the metrics is considered invalid:
-  - `/[\x20-\x7E]{1,28}/`.
-  - 1 to 28 standard ascii characters, excluding control chars (codes: 32-126).
+  - `/[\x20-\x7E]{1,36}/`.
+  - 1 to 36 standard ascii characters, excluding control chars (codes: 32-126).
   - If you suspect that your identifiers may not fulfil our length requirements, set the optional `encodeIdentifierInGUID` field to true. 
 - The definition needs to provide enough information to differentiate this entity
  from others. It cannot be a subset nor a superset of any existing definition. If the names of

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Some examples are APPLICATION, HOST or CONTAINER.
  entity will not be synthesized if the value extracted from the metrics is considered invalid:
   - `/[\x20-\x7E]{1,28}/`.
   - 1 to 28 standard ascii characters, excluding control chars (codes: 32-126).
+  - If you suspect that your identifiers may not fulfil our length requirements, set the optional `encodeIdentifierInGUID` field to true. 
 - The definition needs to provide enough information to differentiate this entity
  from others. It cannot be a subset nor a superset of any existing definition. If the names of
   your telemetry attributes are too generic you can define conditions on the value of the field (e.g. `prefix: "eks"`).

--- a/README.md
+++ b/README.md
@@ -20,13 +20,13 @@ so your PR will get merged faster, and you can start enjoying your shiny new ent
 We use the `domain`, `type` and `identifier` to assign each entity a Global Unique Identifier (GUID).
 - The `domain` must be a value matching `/[A-Z][A-Z0-9_]{2,7}/`. This field is mostly relevant internally for NR. 
 Use EXT by default, although we may advise to use a different value in some cases.                
-- The `type` must be a value matching `/[A-Z][A-Z0-9_]{2,11}/`. This field is meant to identify the type of entity. 
+- The `type` must be a value matching `/[A-Z][A-Z0-9_]{2,19}/`. This field is meant to identify the type of entity. 
 Some examples are APPLICATION, HOST or CONTAINER.  
 - The `identifier` must be assigned a parameter that is unique within the domain and type (e.g
 . cluster ID, host ID, etc). Keep in mind that the value has the following restrictions and that the
  entity will not be synthesized if the value extracted from the metrics is considered invalid:
-  - `/[\x20-\x7E]{1,36}/`.
-  - 1 to 36 standard ascii characters, excluding control chars (codes: 32-126).
+  - `/[\x20-\x7E]{1,28}/`.
+  - 1 to 28 standard ascii characters, excluding control chars (codes: 32-126).
 - The definition needs to provide enough information to differentiate this entity
  from others. It cannot be a subset nor a superset of any existing definition. If the names of
   your telemetry attributes are too generic you can define conditions on the value of the field (e.g. `prefix: "eks"`).

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ so your PR will get merged faster, and you can start enjoying your shiny new ent
 
 - Each entity definition file must live inside its own folder and both must follow the filename format explained below. 
 - The definition MUST be a valid YAML file.
-- The definition must contain at least the following fields: `domain`, `type`, `name`, and `identifier`. 
+- The definition must contain at least the top-level fields `domain` and `type`, along with the fields `name` and `identifier`, located under `synthesis`. 
 We use the `domain`, `type` and `identifier` to assign each entity a Global Unique Identifier (GUID).
 - The `domain` must be a value matching `/[A-Z][A-Z0-9_]{2,7}/`. This field is mostly relevant internally for NR. 
 Use EXT by default, although we may advise to use a different value in some cases.                

--- a/definitions/infra-etcd_cluster/definition.yml
+++ b/definitions/infra-etcd_cluster/definition.yml
@@ -1,26 +1,28 @@
 domain: INFRA
 type: ETCD_CLUSTER
-identifier: clusterName
-name: clusterName
 
-conditions:
-  - attribute: metricName
-    prefix: etcd_
+synthesis:
+  identifier: clusterName
+  name: clusterName
 
-tags:
-  - label.topology.kubernetes.io/region
-  - label.topology.kubernetes.io/zone
-  - label.eks.amazonaws.com/compute-type
-  - k8s.cluster.name
-  - label.kubernetes.io/arch
-  - label.kubernetes.io/hostname
-  - label.kubernetes.io/os
+  conditions:
+    - attribute: metricName
+      prefix: etcd_
 
-dashboardTemplate: ./dashboard.json
+  tags:
+    - label.topology.kubernetes.io/region
+    - label.topology.kubernetes.io/zone
+    - label.eks.amazonaws.com/compute-type
+    - k8s.cluster.name
+    - label.kubernetes.io/arch
+    - label.kubernetes.io/hostname
+    - label.kubernetes.io/os
 
-goldenTags:
-  - label.kubernetes.io/os
+  dashboardTemplate: ./dashboard.json
 
-compositeMetrics:
-  goldenMetrics: ./golden_metrics.yml
-  summaryMetrics: ./summary_metrics.yml
+  goldenTags:
+    - label.kubernetes.io/os
+
+  compositeMetrics:
+    goldenMetrics: ./golden_metrics.yml
+    summaryMetrics: ./summary_metrics.yml

--- a/definitions/infra-kubernetes_apiserver/definition.yml
+++ b/definitions/infra-kubernetes_apiserver/definition.yml
@@ -1,24 +1,26 @@
 domain: INFRA
 type: KUBERNETES_APISERVER
-identifier: clusterName
-name: clusterName
 
-conditions:
-  - attribute: metricName
-    prefix: apiserver_
+synthesis:
+  identifier: clusterName
+  name: clusterName
 
-tags:
-  - label.topology.kubernetes.io/region
-  - label.topology.kubernetes.io/zone
-  - label.eks.amazonaws.com/compute-type
-  - k8s.cluster.name
-  - label.kubernetes.io/arch
-  - label.kubernetes.io/hostname
-  - label.kubernetes.io/os
+  conditions:
+    - attribute: metricName
+      prefix: apiserver_
 
-goldenTags:
-  - label.kubernetes.io/os
+  tags:
+    - label.topology.kubernetes.io/region
+    - label.topology.kubernetes.io/zone
+    - label.eks.amazonaws.com/compute-type
+    - k8s.cluster.name
+    - label.kubernetes.io/arch
+    - label.kubernetes.io/hostname
+    - label.kubernetes.io/os
 
-compositeMetrics:
-  goldenMetrics: ./golden_metrics.yml
-  summaryMetrics: ./summary_metrics.yml
+  goldenTags:
+    - label.kubernetes.io/os
+
+  compositeMetrics:
+    goldenMetrics: ./golden_metrics.yml
+    summaryMetrics: ./summary_metrics.yml

--- a/docs/example-entity-definition.yml
+++ b/docs/example-entity-definition.yml
@@ -1,26 +1,29 @@
 # -- Mandatory fields --
 domain: DOMAIN
 type: TYPE
-name: attributeNameA
-identifier: attributeNameA
 
-# -- Optional fields --
-conditions:
-  - attribute: attributeNameA
-    value: value
-  - attribute: attributeNameB
-    prefix: val
+synthesis:
+  # -- Mandatory fields --
+  name: attributeNameA
+  identifier: attributeNameA
 
-tags:
-  - attributeNameB
-  - attributeNameC
+  # -- Optional fields --
+  conditions:
+    - attribute: attributeNameA
+      value: value
+    - attribute: attributeNameB
+      prefix: val
 
-dashboardTemplate: dashboardUrl
+  tags:
+    - attributeNameB
+    - attributeNameC
 
-compositeMetrics:
-  goldenMetrics: ./domain-type-golden_metrics.yml
-  summaryMetrics: ./domain-type-summary_metrics.yml
+  dashboardTemplate: dashboardUrl
 
-goldenTags:
-  - tagNameA
-  - tagNameB
+  compositeMetrics:
+    goldenMetrics: ./domain-type-golden_metrics.yml
+    summaryMetrics: ./domain-type-summary_metrics.yml
+
+  goldenTags:
+    - tagNameA
+    - tagNameB

--- a/docs/example-entity-definition.yml
+++ b/docs/example-entity-definition.yml
@@ -8,6 +8,10 @@ synthesis:
   identifier: attributeNameA
 
   # -- Optional fields --
+
+  # set to true if the identifier is expected to be longer than 28 characters, defaults to false
+  encodeIdentifierInGUID: false
+
   conditions:
     - attribute: attributeNameA
       value: value

--- a/validator/schemas/entity-schema-v1.json
+++ b/validator/schemas/entity-schema-v1.json
@@ -81,7 +81,7 @@
     "type": {
       "$id": "#/properties/type",
       "type": "string",
-      "pattern": "^[A-Z][A-Z0-9_]{2,19}$",
+      "pattern": "^[A-Z][A-Z0-9_]{2,11}$",
       "title": "The entity type",
       "description": "Information used to synthesize the entity type",
       "examples": [

--- a/validator/schemas/entity-schema-v1.json
+++ b/validator/schemas/entity-schema-v1.json
@@ -81,7 +81,7 @@
     "type": {
       "$id": "#/properties/type",
       "type": "string",
-      "pattern": "^[A-Z][A-Z0-9_]{2,11}$",
+      "pattern": "^[A-Z][A-Z0-9_]{2,}$",
       "title": "The entity type",
       "description": "Information used to synthesize the entity type",
       "examples": [

--- a/validator/schemas/entity-schema-v1.json
+++ b/validator/schemas/entity-schema-v1.json
@@ -4,69 +4,68 @@
   "type": "object",
   "title": "Entity synthesis schema",
   "description": "Schema used to verify that a given entity yaml is valid",
-  "default": {},
   "examples": [
     {
       "domain": "DomainName",
       "type": "TypeName",
-      "name": "EntityName",
-      "identifier": "12345",
-      "conditions": [
-        {
-          "attribute": "attributeName",
-          "value": "value"
-        },
-        {
-          "attribute": "attributeName",
-          "prefix": "value"
-        }
-      ],
-      "dashboardTemplate": "url@github.com",
-      "tags": [
-        "attributeName",
-        "attributeName2"
-      ],
-      "compositeMetrics": {
-        "goldenMetrics": [
+      "synthesis": {
+        "name": "EntityName",
+        "identifier": "12345",
+        "conditions": [
           {
-            "metricName": "metricName",
-            "title": "What the user is seeing (unit)",
-            "displayAsValue": false,
-            "query": {
-              "select": "average(metricAttribute)",
-              "from": "Metric",
-              "where": "",
-              "facet": "entity.guid",
-              "eventId": "entity.guid",
-              "eventObjectId": "ENTITY_GUIDS"
-            }
+            "attribute": "attributeName",
+            "value": "value"
+          },
+          {
+            "attribute": "attributeName",
+            "prefix": "value"
           }
         ],
-        "summaryMetrics": [
-          {
-            "metricName": "metricName",
-            "title": "What the user is seeing (unit)",
-            "query": {
-              "select": "sum(metricAttribute)",
-              "from": "Metric",
-              "where": "",
-              "facet": "entity.guid",
-              "eventObjectId": "ENTITY_GUIDS"
+        "dashboardTemplate": "url@github.com",
+        "tags": [
+          "attributeName",
+          "attributeName2"
+        ],
+        "compositeMetrics": {
+          "goldenMetrics": [
+            {
+              "metricName": "metricName",
+              "title": "What the user is seeing (unit)",
+              "displayAsValue": false,
+              "query": {
+                "select": "average(metricAttribute)",
+                "from": "Metric",
+                "where": "",
+                "facet": "entity.guid",
+                "eventId": "entity.guid",
+                "eventObjectId": "ENTITY_GUIDS"
+              }
             }
-          }
+          ],
+          "summaryMetrics": [
+            {
+              "metricName": "metricName",
+              "title": "What the user is seeing (unit)",
+              "query": {
+                "select": "sum(metricAttribute)",
+                "from": "Metric",
+                "where": "",
+                "facet": "entity.guid",
+                "eventObjectId": "ENTITY_GUIDS"
+              }
+            }
+          ]
+        },
+        "goldenTags": [
+          "nrTagName",
+          "nrTagName2"
         ]
-      },
-      "goldenTags": [
-        "nrTagName",
-        "nrTagName2"
-      ]
+      }
     }
   ],
   "required": [
     "domain",
-    "type",
-    "name",
-    "identifier"
+    "type"
   ],
   "properties": {
     "domain": {
@@ -87,242 +86,310 @@
         "TypeName"
       ]
     },
-    "name": {
-      "$id": "#/properties/name",
-      "type": "string",
-      "title": "The entity name",
-      "description": "Information used to synthesize the entity name",
+    "synthesis": {
+      "$id": "#/properties/synthesis",
+      "type": "object",
+      "title": "Synthesis information",
+      "description": "Information necessary to synthesize the entity",
       "examples": [
-        "EntityName"
-      ]
-    },
-    "identifier": {
-      "$id": "#/properties/identifier",
-      "type": "string",
-      "title": "The entity id",
-      "description": "Information used to synthesize the entity id",
-      "examples": [
-        "12345"
-      ]
-    },
-    "conditions": {
-      "$id": "#/properties/conditions",
-      "type": "array",
-      "title": "Conditions for the entity to be synthesized",
-      "description": "Allows to specify that an attribute's value needs to match a specific value or have a specific prefix.",
-      "examples": [
-        [
-          {
-            "attribute": "attributeName",
-            "value": "value"
+        {
+          "name": "EntityName",
+          "identifier": "12345",
+          "conditions": [
+            {
+              "attribute": "attributeName",
+              "value": "value"
+            },
+            {
+              "attribute": "attributeName",
+              "prefix": "value"
+            }
+          ],
+          "dashboardTemplate": "url@github.com",
+          "tags": [
+            "attributeName",
+            "attributeName2"
+          ],
+          "compositeMetrics": {
+            "goldenMetrics": [
+              {
+                "metricName": "metricName",
+                "title": "What the user is seeing (unit)",
+                "displayAsValue": false,
+                "query": {
+                  "select": "average(metricAttribute)",
+                  "from": "Metric",
+                  "where": "",
+                  "facet": "entity.guid",
+                  "eventId": "entity.guid",
+                  "eventObjectId": "ENTITY_GUIDS"
+                }
+              }
+            ],
+            "summaryMetrics": [
+              {
+                "metricName": "metricName",
+                "title": "What the user is seeing (unit)",
+                "query": {
+                  "select": "sum(metricAttribute)",
+                  "from": "Metric",
+                  "where": "",
+                  "facet": "entity.guid",
+                  "eventObjectId": "ENTITY_GUIDS"
+                }
+              }
+            ]
           },
-          {
-            "attribute": "attributeName",
-            "prefix": "value"
-          }
-        ]
+          "goldenTags": [
+            "nrTagName",
+            "nrTagName2"
+          ]
+        }
       ],
-      "additionalItems": true,
-      "items": {
-        "$id": "#/properties/conditions/items",
-        "anyOf": [
-          {
-            "$id": "#/properties/conditions/items/anyOf/0",
-            "type": "object",
-            "title": "Match attribute value",
-            "description": "An attribute's value needs to match the provided one",
-            "examples": [
+      "required": [
+        "name",
+        "identifier"
+      ],
+      "properties": {
+        "name": {
+          "$id": "#/properties/name",
+          "type": "string",
+          "title": "The entity name",
+          "description": "Information used to synthesize the entity name",
+          "examples": [
+            "EntityName"
+          ]
+        },
+        "identifier": {
+          "$id": "#/properties/identifier",
+          "type": "string",
+          "title": "The entity id",
+          "description": "Information used to synthesize the entity id",
+          "examples": [
+            "12345"
+          ]
+        },
+        "conditions": {
+          "$id": "#/properties/conditions",
+          "type": "array",
+          "title": "Conditions for the entity to be synthesized",
+          "description": "Allows to specify that an attribute's value needs to match a specific value or have a specific prefix.",
+          "examples": [
+            [
               {
                 "attribute": "attributeName",
                 "value": "value"
-              }
-            ],
-            "required": [
-              "attribute",
-              "value"
-            ],
-            "properties": {
-              "attribute": {
-                "$id": "#/properties/conditions/items/anyOf/0/properties/attribute",
-                "type": "string",
-                "title": "The attribute name",
-                "examples": [
-                  "attributeName"
-                ]
               },
-              "value": {
-                "$id": "#/properties/conditions/items/anyOf/0/properties/value",
-                "type": "string",
-                "title": "The expected value",
-                "examples": [
-                  "value"
-                ]
-              }
-            }
-          },
-          {
-            "$id": "#/properties/conditions/items/anyOf/1",
-            "type": "object",
-            "title": "Match attribute value's prefix",
-            "description": "An attribute's value prefix needs to match the provided one",
-            "examples": [
               {
                 "attribute": "attributeName",
                 "prefix": "value"
               }
-            ],
-            "required": [
-              "attribute",
-              "prefix"
-            ],
-            "properties": {
-              "attribute": {
-                "$id": "#/properties/conditions/items/anyOf/1/properties/attribute",
-                "type": "string",
-                "title": "The attribute name",
+            ]
+          ],
+          "additionalItems": true,
+          "items": {
+            "$id": "#/properties/conditions/items",
+            "anyOf": [
+              {
+                "$id": "#/properties/conditions/items/anyOf/0",
+                "type": "object",
+                "title": "Match attribute value",
+                "description": "An attribute's value needs to match the provided one",
                 "examples": [
-                  "attributeName"
-                ]
-              },
-              "prefix": {
-                "$id": "#/properties/conditions/items/anyOf/1/properties/prefix",
-                "type": "string",
-                "title": "The expected prefix",
-                "examples": [
+                  {
+                    "attribute": "attributeName",
+                    "value": "value"
+                  }
+                ],
+                "required": [
+                  "attribute",
                   "value"
-                ]
+                ],
+                "properties": {
+                  "attribute": {
+                    "$id": "#/properties/conditions/items/anyOf/0/properties/attribute",
+                    "type": "string",
+                    "title": "The attribute name",
+                    "examples": [
+                      "attributeName"
+                    ]
+                  },
+                  "value": {
+                    "$id": "#/properties/conditions/items/anyOf/0/properties/value",
+                    "type": "string",
+                    "title": "The expected value",
+                    "examples": [
+                      "value"
+                    ]
+                  }
+                }
+              },
+              {
+                "$id": "#/properties/conditions/items/anyOf/1",
+                "type": "object",
+                "title": "Match attribute value's prefix",
+                "description": "An attribute's value prefix needs to match the provided one",
+                "examples": [
+                  {
+                    "attribute": "attributeName",
+                    "prefix": "value"
+                  }
+                ],
+                "required": [
+                  "attribute",
+                  "prefix"
+                ],
+                "properties": {
+                  "attribute": {
+                    "$id": "#/properties/conditions/items/anyOf/1/properties/attribute",
+                    "type": "string",
+                    "title": "The attribute name",
+                    "examples": [
+                      "attributeName"
+                    ]
+                  },
+                  "prefix": {
+                    "$id": "#/properties/conditions/items/anyOf/1/properties/prefix",
+                    "type": "string",
+                    "title": "The expected prefix",
+                    "examples": [
+                      "value"
+                    ]
+                  }
+                }
               }
-            }
+            ]
           }
-        ]
-      }
-    },
-    "dashboardTemplate": {
-      "$id": "#/properties/dashboardTemplate",
-      "type": "string",
-      "title": "The dashboardTemplate schema",
-      "description": "Template of the dashboard to generate",
-      "examples": [
-        "url@github.com"
-      ]
-    },
-    "compositeMetrics": {
-      "$id": "#/properties/compositeMetrics",
-      "type": "object",
-      "title": "Composite metrics related to the entity.",
-      "description": "Composite metrics such as the goldenMetrics and summaryMetrics.",
-      "examples": [
-        {
-          "goldenMetrics": [
+        },
+        "dashboardTemplate": {
+          "$id": "#/properties/dashboardTemplate",
+          "type": "string",
+          "title": "The dashboardTemplate schema",
+          "description": "Template of the dashboard to generate",
+          "examples": [
+            "url@github.com"
+          ]
+        },
+        "compositeMetrics": {
+          "$id": "#/properties/compositeMetrics",
+          "type": "object",
+          "title": "Composite metrics related to the entity.",
+          "description": "Composite metrics such as the goldenMetrics and summaryMetrics.",
+          "examples": [
             {
-              "metricName": "memoryUsage",
-              "title": "What the user is seeing (unit)",
-              "displayAsValue": false,
-              "query": {
-                "select": "average(host.memoryUsagePercent)",
-                "from": "Metric",
-                "where": "",
-                "facet": "entity.name",
-                "eventId": "entity.guid",
-                "eventObjectId": "ENTITY_GUIDS"
-              }
+              "goldenMetrics": [
+                {
+                  "metricName": "memoryUsage",
+                  "title": "What the user is seeing (unit)",
+                  "displayAsValue": false,
+                  "query": {
+                    "select": "average(host.memoryUsagePercent)",
+                    "from": "Metric",
+                    "where": "",
+                    "facet": "entity.name",
+                    "eventId": "entity.guid",
+                    "eventObjectId": "ENTITY_GUIDS"
+                  }
+                }
+              ],
+              "summaryMetrics": [
+                {
+                  "metricName": "volumeRead",
+                  "title": "What the user is seeing (unit)",
+                  "query": {
+                    "select": "sum(`provider.volumeReadOps.Sum`)",
+                    "from": "Metric",
+                    "where": "",
+                    "facet": "entity.guid",
+                    "eventObjectId": "ENTITY_GUIDS"
+                  }
+                }
+              ]
             }
           ],
-          "summaryMetrics": [
+          "anyOf": [
             {
-              "metricName": "volumeRead",
-              "title": "What the user is seeing (unit)",
-              "query": {
-                "select": "sum(`provider.volumeReadOps.Sum`)",
-                "from": "Metric",
-                "where": "",
-                "facet": "entity.guid",
-                "eventObjectId": "ENTITY_GUIDS"
-              }
+              "required": [
+                "goldenMetrics"
+              ]
+            },
+            {
+              "required": [
+                "summaryMetrics"
+              ]
             }
-          ]
-        }
-      ],
-      "anyOf": [
-        {
-          "required": [
-            "goldenMetrics"
-          ]
+          ],
+          "properties": {
+            "goldenMetrics": {
+              "$id": "#/properties/compositeMetrics/properties/goldenMetrics",
+              "type": "string",
+              "title": "The reference to the golden metrics file",
+              "description": "The reference to the golden metrics file",
+              "examples": [
+                "./domain-type-golden_metrics.yml"
+              ]
+            },
+            "summaryMetrics": {
+              "$id": "#/properties/compositeMetrics/properties/summaryMetrics",
+              "type": "string",
+              "title": "The reference to the summary metrics file",
+              "description": "The reference to the summary metrics file",
+              "examples": [
+                "./domain-type-summary_metrics.yml"
+              ]
+            }
+          },
+          "additionalProperties": false
         },
-        {
-          "required": [
-            "summaryMetrics"
-          ]
-        }
-      ],
-      "properties": {
-        "goldenMetrics": {
-          "$id": "#/properties/compositeMetrics/properties/goldenMetrics",
-          "type": "string",
-          "title": "The reference to the golden metrics file",
-          "description": "The reference to the golden metrics file",
+        "tags": {
+          "$id": "#/properties/tags",
+          "type": "array",
+          "title": "An array of tags.",
+          "description": "Tags associated to the entity that can be extracted from the metrics information received.",
           "examples": [
-            "./domain-type-golden_metrics.yml"
-          ]
+            [
+              "attributeName",
+              "attributeName2"
+            ]
+          ],
+          "additionalItems": false,
+          "items": {
+            "$id": "#/properties/tags/items",
+            "anyOf": [
+              {
+                "$id": "#/properties/tags/items/anyOf/0",
+                "type": "string",
+                "title": "Reference to a tag extracted from metrics"
+              }
+            ]
+          }
         },
-        "summaryMetrics": {
-          "$id": "#/properties/compositeMetrics/properties/summaryMetrics",
-          "type": "string",
-          "title": "The reference to the summary metrics file",
-          "description": "The reference to the summary metrics file",
+        "goldenTags": {
+          "$id": "#/properties/goldenTags",
+          "type": "array",
+          "title": "An array of goldenTags",
+          "description": "The golden tags associated to the entity. They must be existing NewRelic tags, which are comprised by tags extracted from the metric and defined here and tags injected by NewRelic.",
           "examples": [
-            "./domain-type-summary_metrics.yml"
-          ]
+            [
+              "nrTagName",
+              "nrTagName2"
+            ]
+          ],
+          "additionalItems": false,
+          "items": {
+            "$id": "#/properties/goldenTags/items",
+            "anyOf": [
+              {
+                "$id": "#/properties/goldenTags/items/anyOf/0",
+                "type": "string",
+                "title": "Reference to a NewRelic tag"
+              }
+            ]
+          }
         }
       },
-      "additionalProperties": true
-    },
-    "tags": {
-      "$id": "#/properties/tags",
-      "type": "array",
-      "title": "An array of tags.",
-      "description": "Tags associated to the entity that can be extracted from the metrics information received.",
-      "examples": [
-        [
-          "attributeName",
-          "attributeName2"
-        ]
-      ],
-      "additionalItems": false,
-      "items": {
-        "$id": "#/properties/tags/items",
-        "anyOf": [
-          {
-            "$id": "#/properties/tags/items/anyOf/0",
-            "type": "string",
-            "title": "Reference to a tag extracted from metrics"
-          }
-        ]
-      }
-    },
-    "goldenTags": {
-      "$id": "#/properties/goldenTags",
-      "type": "array",
-      "title": "An array of goldenTags",
-      "description": "The golden tags associated to the entity. They must be existing NewRelic tags, which are comprised by tags extracted from the metric and defined here and tags injected by NewRelic.",
-      "examples": [
-        [
-          "nrTagName",
-          "nrTagName2"
-        ]
-      ],
-      "additionalItems": false,
-      "items": {
-        "$id": "#/properties/goldenTags/items",
-        "anyOf": [
-          {
-            "$id": "#/properties/goldenTags/items/anyOf/0",
-            "type": "string",
-            "title": "Reference to a NewRelic tag"
-          }
-        ]
-      }
+      "additionalProperties": false
     }
   },
-  "additionalProperties": true
+  "additionalProperties": false
 }

--- a/validator/schemas/entity-schema-v1.json
+++ b/validator/schemas/entity-schema-v1.json
@@ -71,6 +71,7 @@
     "domain": {
       "$id": "#/properties/domain",
       "type": "string",
+      "pattern": "^[A-Z][A-Z0-9_]{2,7}$",
       "title": "The entity domain",
       "description": "Information used to synthesize the entity domain",
       "examples": [
@@ -80,6 +81,7 @@
     "type": {
       "$id": "#/properties/type",
       "type": "string",
+      "pattern": "^[A-Z][A-Z0-9_]{2,19}$",
       "title": "The entity type",
       "description": "Information used to synthesize the entity type",
       "examples": [

--- a/validator/schemas/entity-schema-v1.json
+++ b/validator/schemas/entity-schema-v1.json
@@ -171,6 +171,13 @@
             "12345"
           ]
         },
+        "encodeIdentifierInGUID": {
+          "$id": "#/properties/encodeIdentifierInGUID",
+          "type": "boolean",
+          "default": false,
+          "title": "encode identifier in GUID",
+          "description": "Defines whether the identifier should be encoded in the entity GUID, to be used when the identifier is too long."
+        },
         "conditions": {
           "$id": "#/properties/conditions",
           "type": "array",

--- a/validator/tools/utils.js
+++ b/validator/tools/utils.js
@@ -16,8 +16,9 @@ async function getFiles(dir) {
 
 module.exports = {
     async getAllDefinitions() {
-        var files = await getFiles(DEFINITIONS_DIR)
-        return files.map((filename) => {
+        const files = await getFiles(DEFINITIONS_DIR)
+        const definitionFiles = files.filter(file => file.includes('definition.yml'))
+        return definitionFiles.map((filename) => {
                 return yaml.safeLoad(fs.readFileSync(filename, 'utf8'));
             }
         )

--- a/validator/tools/validate_uniqueness.js
+++ b/validator/tools/validate_uniqueness.js
@@ -33,11 +33,13 @@ const RULES = [
     {
         name: 'Entities with the same id and conditions must have the same domain and type',
         apply: def => {
-            if (ENTITY.has(def.identifier) && hasSameConditions(ENTITY.get(def.identifier), def) && hasDifferentDomainType(ENTITY.get(def.identifier), def)) {
-                throw `Same entity ID criteria ${def.identifier} and conditions assigned to different domain types.`
-            }
+            if(def.identifier != undefined) {
+                if (ENTITY.has(def.identifier) && hasSameConditions(ENTITY.get(def.identifier), def) && hasDifferentDomainType(ENTITY.get(def.identifier), def)) {
+                    throw `Same entity ID criteria ${def.identifier} and conditions assigned to different domain types.`
+                }
 
-            ENTITY.set(def.identifier, def)
+                ENTITY.set(def.identifier, def)
+            }
         }
     }
 ]


### PR DESCRIPTION
### Relevant information

Updated the entity definition schema so that we can start composite metrics for entities that will not be synthesized from this repository. 

### Checklist

* [x] I've read the guidelines and understand the acceptance criteria.
* [x] The value of the attribute marked as `identifier` will be unique and valid. 
* [x] This is not my first contribution, or I've reached out to the team by opening an issue before
 opening this PR. 
* [x] I've confirmed that my entity type wasn't already defined. If it is I'm providing an
 explanation above.
