### PR TITLE
Add script to migrate internal definitions

### DIFF
--- a/migrations/README.md
+++ b/migrations/README.md
@@ -1,0 +1,30 @@
+# Migrate definitions
+
+The `migrateDefinitions` script will create non-synthesizable entity definitions on the [definitions](../definitions) folder based on the entities defined internally. 
+Then it will create a new branch, stage and commit the changes, so that you can verify that everything is correct and just push. 
+
+## Execute the script
+
+Create a virtual environment with python 3.x to execute the script
+
+```bash
+virtualenv venv -p python3.8
+```
+
+Activate the environment
+
+```bash
+source venv/bin/activate
+```
+
+Install the dependencies
+
+```bash
+pip install -r requirements.txt
+```
+
+Execute the `migrateDefinitions` script providing the URL of the schema registry in the environment you wish to import the definitions from:
+
+```bash
+python3 migrateDefinitions.py <SERVICE_URL>
+```

--- a/migrations/migrateDefinitions.py
+++ b/migrations/migrateDefinitions.py
@@ -1,0 +1,55 @@
+import os
+import sys
+import requests
+from git import Repo
+from time import time
+
+FILENAME = 'definition.yml'
+
+def getDefsDir(relPath):
+    return os.path.join("../definitions", relPath)
+
+def getEntitySchemas(url):
+    endpoint = "/v2/entity-types"
+    request = requests.get(url+endpoint)
+    if request.status_code == 200:
+        return request.json()["entityIndexTypes"]
+    else:
+        raise Exception("Request failed, returning code {}.".format(request.status_code))
+
+def createDefinition(domain, type):
+    folderName = ("%s-%s" %(domain, type)).lower()
+    if not os.path.exists(getDefsDir(folderName)):
+        os.makedirs(getDefsDir(folderName))
+        with open(os.path.join(getDefsDir(folderName), FILENAME), 'w') as temp_file:
+            temp_file.write("domain: %s" % domain)
+            temp_file.write("\n")
+            temp_file.write("type: %s" % type)
+        return 1
+    else:
+        return 0
+
+def importEntityDefinitions(url):
+    entitySchemas = getEntitySchemas(url)
+    newDefinitions = 0
+    for schema in entitySchemas:
+        domain = schema['domain']
+        type = schema['rawEntityType']
+        newDefinitions += createDefinition(domain, type)
+    print("Created %d new definitions" % newDefinitions)
+
+def commitToNewBranch():
+    repo = Repo('../')
+    new_branch = repo.create_head('import-definitions-'+str(time()))
+    repo.head.reference = new_branch
+    repo.git.add('./definitions/')
+    repo.git.commit('-m', 'Migrated new entity definitions')
+
+
+
+if(len(sys.argv) < 2):
+    exit("Please provide the URL of the schema service for the environment you wish want to use")
+url = sys.argv[1]
+importEntityDefinitions(url)
+commitToNewBranch()
+

--- a/migrations/requirements.txt
+++ b/migrations/requirements.txt
@@ -1,0 +1,2 @@
+GitPython==3.1.11
+requests==2.25.0


### PR DESCRIPTION
### Relevant information

Added a script to migrate internal definitions, making this a draft to discuss whether this is the right approach. 
I'll run the script if this is accepted because it adds a lot of noise to the PR. 

### Checklist

* [ ] I've read the guidelines and understand the acceptance criteria.
* [ ] The value of the attribute marked as `identifier` will be unique and valid. 
* [ ] This is not my first contribution, or I've reached out to the team by opening an issue before
 opening this PR. 
* [ ] I've confirmed that my entity type wasn't already defined. If it is I'm providing an
 explanation above.
