### PR TITLE
Mention workloads in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # Entity Synthesis Definitions 
 
-The definition files contained in this repository are mappings between the telemetry attributes NewRelic ingests, and the entities users can interact with. If you have telemetry from any source that is not supported out of the box, you can propose a mapping for it and upon a successful merge of your PR, any telemetry received by NewRelic and that matches your definition file will be synthesized into an entity. Then you can start leveraging any of the tools built around them such as the entity explorer, high-density views, etc.
+The definition files contained in this repository are mappings between the telemetry attributes NewRelic ingests, and the entities users can interact with. If you have telemetry from any source that is not supported out of the box, you can propose a mapping for it and upon a successful merge of your PR, any telemetry received by NewRelic and that matches your definition file will be synthesized into an entity. Then you can start leveraging any of the tools built around them such as the entity explorer, high-density views, workloads, etc.
 
 ## Guidelines 
 


### PR DESCRIPTION
### Relevant information

I've added Workloads as an example of experience where entity types are essential, in particular for customers to see the golden metrics and the status surfaced on the Workloads UI. 

### Checklist
I haven't followed the checklist strictly, because I'm proposing a minor change in the README.md file.