### PR TITLE
Github workflow improvements

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+*       @cianbuckley @srvaroa @gvassallo @irenemlc

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-*       @cianbuckley @srvaroa @gvassallo @irenemlc
+*       @cianbuckley @srvaroa @gvassallo @naxhh @irenemlc

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -8,5 +8,3 @@ Describe what you have done and any details that you think are relevant or that 
 * [ ] The value of the attribute marked as `identifier` will be unique and valid. 
 * [ ] This is not my first contribution, or I've reached out to the team by opening an issue before
  opening this PR. 
-* [ ] I've confirmed that my entity type wasn't already defined. If it is I'm providing an
- explanation above.


### PR DESCRIPTION
### Relevant information

Based on feedback, remove last step on PR checklist `I've confirmed that my entity type wasn't already defined. If it is I'm providing an explanation above.`

Add codeowners. Maybe I should take out @gvassallo since he's actively working on other things, but I rather you choose. 

