### PR TITLE
Add - as a valid character in type names

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ so your PR will get merged faster, and you can start enjoying your shiny new ent
 We use the `domain`, `type` and `identifier` to assign each entity a Global Unique Identifier (GUID).
 - The `domain` must be a value matching `/[A-Z][A-Z0-9_]{2,7}/`. This field is mostly relevant internally for NR. 
 Use EXT by default, although we may advise to use a different value in some cases.                
-- The `type` must be a value matching `/[A-Z][A-Z0-9_]{2,11}/`. This field is meant to identify the type of entity. 
+- The `type` must be a value matching `/[A-Z][A-Z0-9_-]{2,11}/`. This field is meant to identify the type of entity. 
 Some examples are APPLICATION, HOST or CONTAINER.  
 - The `identifier` must be assigned a parameter that is unique within the domain and type (e.g
 . cluster ID, host ID, etc). Keep in mind that the value has the following restrictions and that the

--- a/validator/schemas/entity-schema-v1.json
+++ b/validator/schemas/entity-schema-v1.json
@@ -42,7 +42,7 @@
     "type": {
       "$id": "#/properties/type",
       "type": "string",
-      "pattern": "^[A-Z][A-Z0-9_]{2,}$",
+      "pattern": "^[A-Z][A-Z0-9_-]{2,}$",
       "title": "The entity type",
       "description": "Information used to synthesize the entity type",
       "examples": [


### PR DESCRIPTION
### Relevant information

Some migrated entity types contain '-' despite it not being on the original spec regex, so I'm adding it now
