### PR TITLE
Take the composite metrics and golden tags out of the synthesis section

### DIFF
--- a/definitions/infra-etcd_cluster/definition.yml
+++ b/definitions/infra-etcd_cluster/definition.yml
@@ -18,14 +18,14 @@ synthesis:
     - label.kubernetes.io/hostname
     - label.kubernetes.io/os
 
-  dashboardTemplates:
-    - ./dashboard.json
+dashboardTemplates:
+  - ./dashboard.json
 
-  goldenTags:
-    - label.kubernetes.io/os
+goldenTags:
+  - label.kubernetes.io/os
 
-  compositeMetrics:
-    goldenMetrics:
-      - ./golden_metrics.yml
-    summaryMetrics:
-      - ./summary_metrics.yml
+compositeMetrics:
+  goldenMetrics:
+    - ./golden_metrics.yml
+  summaryMetrics:
+    - ./summary_metrics.yml

--- a/definitions/infra-kubernetes_apiserver/definition.yml
+++ b/definitions/infra-kubernetes_apiserver/definition.yml
@@ -18,11 +18,11 @@ synthesis:
     - label.kubernetes.io/hostname
     - label.kubernetes.io/os
 
-  goldenTags:
-    - label.kubernetes.io/os
+goldenTags:
+  - label.kubernetes.io/os
 
-  compositeMetrics:
-    goldenMetrics:
-      - ./golden_metrics.yml
-    summaryMetrics:
-      - ./summary_metrics.yml
+compositeMetrics:
+  goldenMetrics:
+    - ./golden_metrics.yml
+  summaryMetrics:
+    - ./summary_metrics.yml

--- a/docs/example-entity-definition.yml
+++ b/docs/example-entity-definition.yml
@@ -29,20 +29,20 @@ synthesis:
     - attributeNameB
     - attributeNameC
 
-  # Template that can be used to generate a dashboard for the entity.
-  dashboardTemplates:
-   - ./dashboard.json
+# Template that can be used to generate a dashboard for the entity.
+dashboardTemplates:
+ - ./dashboard.json
 
-  # Reference to the golden and/or summary metrics associated with the entity (if any).
-  compositeMetrics:
-    goldenMetrics:
-      - ./domain-type-golden_metrics.yml
-    summaryMetrics:
-      - ./domain-type-summary_metrics.yml
+# Reference to the golden and/or summary metrics associated with the entity (if any).
+compositeMetrics:
+  goldenMetrics:
+    - ./domain-type-golden_metrics.yml
+  summaryMetrics:
+    - ./domain-type-summary_metrics.yml
 
-  # The golden tags associated with the entity. They must be existing NewRelic tags which includes:
-  #   - Tags extracted from telemetry attributes and defined here in the `tags` section.
-  #   - Tags added to the entity through other means.
-  goldenTags:
-    - tagNameA
-    - tagNameB
+# The golden tags associated with the entity. They must be existing NewRelic tags which includes:
+#   - Tags extracted from telemetry attributes and defined here in the `tags` section.
+#   - Tags added to the entity through other means.
+goldenTags:
+  - tagNameA
+  - tagNameB

--- a/validator/schemas/entity-schema-v1.json
+++ b/validator/schemas/entity-schema-v1.json
@@ -182,57 +182,6 @@
             ]
           }
         },
-        "dashboardTemplates": {
-          "$id": "#/properties/dashboardTemplates",
-          "type": "array",
-          "description": "An array dashboard templates",
-          "examples": [
-            [
-              "url@github.com"
-            ]
-          ]
-        },
-        "compositeMetrics": {
-          "$id": "#/properties/compositeMetrics",
-          "type": "object",
-          "title": "Composite metrics related to the entity.",
-          "description": "Composite metrics such as the goldenMetrics and summaryMetrics.",
-          "anyOf": [
-            {
-              "required": [
-                "goldenMetrics"
-              ]
-            },
-            {
-              "required": [
-                "summaryMetrics"
-              ]
-            }
-          ],
-          "properties": {
-            "goldenMetrics": {
-              "$id": "#/properties/compositeMetrics/properties/goldenMetrics",
-              "type": "array",
-              "description": "Array of relative paths golden metrics files",
-              "examples": [
-                [
-                  "./domain-type-golden_metrics.yml"
-                ]
-              ]
-            },
-            "summaryMetrics": {
-              "$id": "#/properties/compositeMetrics/properties/summaryMetrics",
-              "type": "array",
-              "description": "Array of relative paths to summary metrics file",
-              "examples": [
-                [
-                  "./domain-type-summary_metrics.yml"
-                ]
-              ]
-            }
-          },
-          "additionalProperties": false
-        },
         "tags": {
           "$id": "#/properties/tags",
           "type": "array",
@@ -255,32 +204,83 @@
               }
             ]
           }
-        },
-        "goldenTags": {
-          "$id": "#/properties/goldenTags",
-          "type": "array",
-          "title": "An array of goldenTags",
-          "description": "The golden tags associated to the entity. They must be existing NewRelic tags, which are comprised by tags extracted from the metric and defined here and tags injected by NewRelic.",
-          "examples": [
-            [
-              "nrTagName",
-              "nrTagName2"
-            ]
-          ],
-          "additionalItems": false,
-          "items": {
-            "$id": "#/properties/goldenTags/items",
-            "anyOf": [
-              {
-                "$id": "#/properties/goldenTags/items/anyOf/0",
-                "type": "string",
-                "title": "Reference to a NewRelic tag"
-              }
-            ]
-          }
         }
       },
       "additionalProperties": false
+    },
+    "dashboardTemplates": {
+      "$id": "#/properties/dashboardTemplates",
+      "type": "array",
+      "description": "An array dashboard templates",
+      "examples": [
+        [
+          "url@github.com"
+        ]
+      ]
+    },
+    "compositeMetrics": {
+      "$id": "#/properties/compositeMetrics",
+      "type": "object",
+      "title": "Composite metrics related to the entity.",
+      "description": "Composite metrics such as the goldenMetrics and summaryMetrics.",
+      "anyOf": [
+        {
+          "required": [
+            "goldenMetrics"
+          ]
+        },
+        {
+          "required": [
+            "summaryMetrics"
+          ]
+        }
+      ],
+      "properties": {
+        "goldenMetrics": {
+          "$id": "#/properties/compositeMetrics/properties/goldenMetrics",
+          "type": "array",
+          "description": "Array of relative paths golden metrics files",
+          "examples": [
+            [
+              "./domain-type-golden_metrics.yml"
+            ]
+          ]
+        },
+        "summaryMetrics": {
+          "$id": "#/properties/compositeMetrics/properties/summaryMetrics",
+          "type": "array",
+          "description": "Array of relative paths to summary metrics file",
+          "examples": [
+            [
+              "./domain-type-summary_metrics.yml"
+            ]
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "goldenTags": {
+      "$id": "#/properties/goldenTags",
+      "type": "array",
+      "title": "An array of goldenTags",
+      "description": "The golden tags associated to the entity. They must be existing NewRelic tags, which are comprised by tags extracted from the metric and defined here and tags injected by NewRelic.",
+      "examples": [
+        [
+          "nrTagName",
+          "nrTagName2"
+        ]
+      ],
+      "additionalItems": false,
+      "items": {
+        "$id": "#/properties/goldenTags/items",
+        "anyOf": [
+          {
+            "$id": "#/properties/goldenTags/items/anyOf/0",
+            "type": "string",
+            "title": "Reference to a NewRelic tag"
+          }
+        ]
+      }
     }
   },
   "additionalProperties": false


### PR DESCRIPTION
### Relevant information

In a previous schema iteration, we moved everything except for the domain and type into the synthesis section, but non-synthesizable entities also have composite metrics and golden tags and they are not really part of the synthesis. 