### PR TITLE
Set encodeIdentifierInGUID in kubernetes_apiserver

### DIFF
--- a/definitions/infra-kubernetes_apiserver/definition.yml
+++ b/definitions/infra-kubernetes_apiserver/definition.yml
@@ -4,6 +4,7 @@ type: KUBERNETES_APISERVER
 synthesis:
   identifier: clusterName
   name: clusterName
+  encodeIdentifierInGUID: true
 
   conditions:
     - attribute: metricName


### PR DESCRIPTION
### Relevant information

The domainId of kubernetes_apiserver is too long so the entity GUIDs break the spec size limit

### Checklist

* [x] I've read the guidelines and understand the acceptance criteria.
* [x] The value of the attribute marked as `identifier` will be unique and valid. 
* [x] I've confirmed that my entity type wasn't already defined. If it is I'm providing an
 explanation above.
