### PR TITLE
Validate golden metrics keys contain valid characters

### DIFF
--- a/docs/golden_metrics.md
+++ b/docs/golden_metrics.md
@@ -6,7 +6,8 @@ We allow a maximum of 10 metrics per entityType.
 
 ## Defining golden metrics
 
-Golden metrics are defined in a map where each key is a camel-case name that defines the intention of the metric: 
+Golden metrics are defined in a map where each key should be unique. The allowed characters are `[a-zA-Z0-9_]` with a maximum of 100 characters.
+This key defines the intention of the metric:
 
 ```yaml
 memoryUsage:

--- a/validator/schemas/golden-metrics-schema-v1.json
+++ b/validator/schemas/golden-metrics-schema-v1.json
@@ -20,6 +20,9 @@
       }
     }
   ],
+  "propertyNames": {
+    "pattern": "^[a-zA-Z0-9_]{1,100}$"
+  },
   "additionalProperties": {
     "type": "object",
     "required": [


### PR DESCRIPTION
### Relevant information

Make the golden metrics key have a valid format.

The format decided is: a-z A-Z 0-9 _ and from 1 character until 100.
All current definitions are ok with this validator so no further changes are required! \o/

### Checklist

* [x] I've read the guidelines and understand the acceptance criteria.
