### PR TITLE
Add missing synthesis rules for entity types

### DIFF
--- a/definitions/ext-browser_app/definition.yml
+++ b/definitions/ext-browser_app/definition.yml
@@ -1,2 +1,7 @@
 domain: EXT
 type: BROWSER_APP
+
+synthesis:
+  identifier: browserApp.name
+  name: browserApp.name
+  encodeIdentifierInGUID: true

--- a/definitions/ext-host/definition.yml
+++ b/definitions/ext-host/definition.yml
@@ -1,2 +1,7 @@
 domain: EXT
 type: HOST
+
+synthesis:
+  identifier: host
+  name: host
+  encodeIdentifierInGUID: true

--- a/definitions/ext-mobile_app/definition.yml
+++ b/definitions/ext-mobile_app/definition.yml
@@ -1,2 +1,7 @@
 domain: EXT
 type: MOBILE_APP
+
+synthesis:
+  identifier: mobileApp.name
+  name: mobileApp.name
+  encodeIdentifierInGUID: true

--- a/definitions/ext-service/definition.yml
+++ b/definitions/ext-service/definition.yml
@@ -1,2 +1,7 @@
 domain: EXT
 type: SERVICE
+
+synthesis:
+  identifier: service.name
+  name: service.name
+  encodeIdentifierInGUID: true


### PR DESCRIPTION
### Relevant information

Added the missing synthesis rules for EXT-BROWSER_APP, EXT-MOBILE_APP, EXT-SERVICE and INFRA-HOST. Still didn't add the rules for containers since there's still a discussion about the approach (and it'll be a breaking change). 