### PR TITLE
Missing conditions in EXT- rules

### DIFF
--- a/definitions/ext-browser_app/definition.yml
+++ b/definitions/ext-browser_app/definition.yml
@@ -5,3 +5,6 @@ synthesis:
   identifier: browserApp.name
   name: browserApp.name
   encodeIdentifierInGUID: true
+
+  conditions:
+    - attribute: browserApp.name

--- a/definitions/ext-host/definition.yml
+++ b/definitions/ext-host/definition.yml
@@ -5,3 +5,6 @@ synthesis:
   identifier: host
   name: host
   encodeIdentifierInGUID: true
+
+  conditions:
+    - attribute: host

--- a/definitions/ext-mobile_app/definition.yml
+++ b/definitions/ext-mobile_app/definition.yml
@@ -5,3 +5,6 @@ synthesis:
   identifier: mobileApp.name
   name: mobileApp.name
   encodeIdentifierInGUID: true
+
+  conditions:
+    - attribute: mobileApp.name

--- a/definitions/ext-service/definition.yml
+++ b/definitions/ext-service/definition.yml
@@ -5,3 +5,6 @@ synthesis:
   identifier: service.name
   name: service.name
   encodeIdentifierInGUID: true
+
+  conditions:
+    - attribute: service.name


### PR DESCRIPTION
Signed-off-by: Galo Navarro <gnavarro@newrelic.com>

### Relevant information

These types had synthesis rules, but no conditions!

### Checklist

* [x] I've read the guidelines and understand the acceptance criteria.
* [x] The value of the attribute marked as `identifier` will be unique and valid. 
* [x] I've confirmed that my entity type wasn't already defined. If it is I'm providing an
 explanation above.
