### PR TITLE
Add expiration configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,28 +125,28 @@ dashboardTemplates:
 
 Note that you can define more than one dashboard under the `dashboardTemplates` field. 
 
-#### Entity TTL
+#### Entity expiration 
 
-Entities are deleted by default 8 days after the last time they were indexed or sent out a heartbeat. 
-If this doesn't suit your needs you may also specify your desired behavior under the TTL section of the main `definition.yml` file:  
+By default, entities are automatically deleted if we reach 8 days without receiving any telemetry from them. 
+If this doesn't suit your needs you may also specify your desired `expirationPolicy` and `expirationTime` under the `expiration` section of the main `definition.yml` file:  
 
 ```yaml
-ttl:
-  # The strategy to follow for the entity deletion. Defaults to AUTOMATIC
-  deletionStrategy: AUTOMATIC
-  # The frequency to delete the entity types. Defaults to EIGHT_DAYS
-  deletionFrequency: EIGHT_DAYS
+expiration:
+  # The entity deletion policy. Defaults to AUTOMATIC
+  expirationPolicy: AUTOMATIC
+  # The amount of time without receiving telemetry before an entity is deleted. Defaults to EIGHT_DAYS
+  expirationTime: EIGHT_DAYS
 ```
 
-`deletionStrategy` accepts the values `AUTOMATIC` (default) and `MANUAL`. 
+`expirationPolicy` accepts the values `AUTOMATIC` (default) and `MANUAL`. 
 
-If `AUTOMATIC` is used the entity will be automatically deleted after a certain amount of time, defined by the `deletionFrequency`: 
+If `AUTOMATIC` is used, the entity will be deleted if we don't receive any telemetry for the time defined by `expirationTime`: 
 - `HOURLY`
 - `DAILY`
 - `EIGHT_DAYS` (default)
 - `QUARTERLY`
 
-If `MANUAL` is used, the `deletionFrequency` field must be left empty or set to `MANUAL`. 
+If `MANUAL` is used, the entity will not be deleted based on an `expirationTime` so the field can be left empty. 
 
 ## Testing and validation
 

--- a/README.md
+++ b/README.md
@@ -125,6 +125,29 @@ dashboardTemplates:
 
 Note that you can define more than one dashboard under the `dashboardTemplates` field. 
 
+#### Entity TTL
+
+Entities are deleted by default 8 days after the last time they were indexed or sent out a heartbeat. 
+If this doesn't suit your needs you may also specify your desired behavior under the TTL section of the main `definition.yml` file:  
+
+```yaml
+ttl:
+  # The strategy to follow when indexing the entity type. Defaults to DELETE_BY_QUERY
+  indexStrategy: DELETE_BY_QUERY
+  # The frequency to delete the entity types. Defaults to EIGHT_DAYS
+  deletionFrequency: EIGHT_DAYS
+```
+
+`indexStrategy` accepts the values `DELETE_BY_QUERY` (default) and `DELETE_BY_DOCUMENT`. 
+
+If `DELETE_BY_QUERY` is used the entity will be automatically deleted after a certain amount of time, defined by the `deletionFrequency`: 
+- `HOURLY`
+- `DAILY`
+- `EIGHT_DAYS` (default)
+- `QUARTERLY`
+
+If `DELETE_BY_DOCUMENT` is used, the `deletionFrequency` field must be set to `MANUAL`. 
+
 ## Testing and validation
 
 Some validations are automatically executed whenever there is a contribution via pull request, to verify that the provided definition meets the basic requirements:

--- a/README.md
+++ b/README.md
@@ -125,27 +125,23 @@ dashboardTemplates:
 
 Note that you can define more than one dashboard under the `dashboardTemplates` field. 
 
-#### Entity expiration 
+#### Configurations
 
-By default, entities are automatically deleted if we reach 8 days without receiving any telemetry from them. 
-If this doesn't suit your needs you may also specify your desired `expirationPolicy` and `expirationTime` under the `expiration` section of the main `definition.yml` file:  
+In the `configuration` section of the `definition.yml` file you can tweak the entity's behavior. At the moment you can only configure the entity's expiration time. 
 
 ```yaml
-expiration:
-  # The entity deletion policy. Defaults to AUTOMATIC
-  expirationPolicy: AUTOMATIC
+configuration:
   # The amount of time without receiving telemetry before an entity is deleted. Defaults to EIGHT_DAYS
-  expirationTime: EIGHT_DAYS
+  entityExpirationTime: EIGHT_DAYS
 ```
 
-`expirationPolicy` accepts the values `AUTOMATIC` (default) and `MANUAL`. 
+By default, entities are automatically deleted if we reach 8 days without receiving any telemetry from them. 
+If this doesn't suit your needs you may set the `entityExpirationTime` to one of the following values:  
 
-If `AUTOMATIC` is used, the entity will be deleted if we don't receive any telemetry for the time defined by `expirationTime`: 
 - `DAILY`
 - `EIGHT_DAYS` (default)
 - `QUARTERLY`
-
-If `MANUAL` is used, the entity will not be deleted based on an `expirationTime` so the field can be left empty. 
+- `MANUAL` (allowed only for entities without a `synthesis` section)
 
 ## Testing and validation
 

--- a/README.md
+++ b/README.md
@@ -141,7 +141,6 @@ expiration:
 `expirationPolicy` accepts the values `AUTOMATIC` (default) and `MANUAL`. 
 
 If `AUTOMATIC` is used, the entity will be deleted if we don't receive any telemetry for the time defined by `expirationTime`: 
-- `HOURLY`
 - `DAILY`
 - `EIGHT_DAYS` (default)
 - `QUARTERLY`

--- a/README.md
+++ b/README.md
@@ -132,21 +132,21 @@ If this doesn't suit your needs you may also specify your desired behavior under
 
 ```yaml
 ttl:
-  # The strategy to follow when indexing the entity type. Defaults to DELETE_BY_QUERY
-  indexStrategy: DELETE_BY_QUERY
+  # The strategy to follow for the entity deletion. Defaults to AUTOMATIC
+  deletionStrategy: AUTOMATIC
   # The frequency to delete the entity types. Defaults to EIGHT_DAYS
   deletionFrequency: EIGHT_DAYS
 ```
 
-`indexStrategy` accepts the values `DELETE_BY_QUERY` (default) and `DELETE_BY_DOCUMENT`. 
+`deletionStrategy` accepts the values `AUTOMATIC` (default) and `MANUAL`. 
 
-If `DELETE_BY_QUERY` is used the entity will be automatically deleted after a certain amount of time, defined by the `deletionFrequency`: 
+If `AUTOMATIC` is used the entity will be automatically deleted after a certain amount of time, defined by the `deletionFrequency`: 
 - `HOURLY`
 - `DAILY`
 - `EIGHT_DAYS` (default)
 - `QUARTERLY`
 
-If `DELETE_BY_DOCUMENT` is used, the `deletionFrequency` field must be set to `MANUAL`. 
+If `MANUAL` is used, the `deletionFrequency` field must be left empty or set to `MANUAL`. 
 
 ## Testing and validation
 

--- a/docs/example-entity-definition.yml
+++ b/docs/example-entity-definition.yml
@@ -47,7 +47,7 @@ goldenTags:
 
 # Defines whether the entities of this type are automatically deleted and with what frequency
 ttl:
-  # The strategy to follow when indexing the entity type. Defaults to DELETE_BY_QUERY
-  indexStrategy: DELETE_BY_QUERY
+  # The strategy to follow for the entity deletion. Defaults to AUTOMATIC
+  deletionStrategy: AUTOMATIC
   # The frequency to delete the entity types. Defaults to EIGHT_DAYS
   deletionFrequency: EIGHT_DAYS

--- a/docs/example-entity-definition.yml
+++ b/docs/example-entity-definition.yml
@@ -45,9 +45,7 @@ goldenTags:
   - tagNameA
   - tagNameB
 
-# Defines whether the entities of this type are automatically deleted after a certain expirationTime without receiving telemetry
-expiration:
-  # The entity deletion policy. Defaults to AUTOMATIC
-  expirationPolicy: AUTOMATIC
+# Additional configurations for a more granular control of the entity's behavior
+configuration:
   # The amount of time without receiving telemetry before an entity is deleted. Defaults to EIGHT_DAYS
-  expirationTime: EIGHT_DAYS
+  entityExpirationTime: EIGHT_DAYS

--- a/docs/example-entity-definition.yml
+++ b/docs/example-entity-definition.yml
@@ -46,8 +46,8 @@ goldenTags:
   - tagNameB
 
 # Defines whether the entities of this type are automatically deleted and with what frequency
-ttl:
+expiration:
   # The strategy to follow for the entity deletion. Defaults to AUTOMATIC
-  deletionStrategy: AUTOMATIC
+  expirationPolicy: AUTOMATIC
   # The frequency to delete the entity types. Defaults to EIGHT_DAYS
-  deletionFrequency: EIGHT_DAYS
+  expirationTime: EIGHT_DAYS

--- a/docs/example-entity-definition.yml
+++ b/docs/example-entity-definition.yml
@@ -45,9 +45,9 @@ goldenTags:
   - tagNameA
   - tagNameB
 
-# Defines whether the entities of this type are automatically deleted and with what frequency
+# Defines whether the entities of this type are automatically deleted after a certain expirationTime without receiving telemetry
 expiration:
-  # The strategy to follow for the entity deletion. Defaults to AUTOMATIC
+  # The entity deletion policy. Defaults to AUTOMATIC
   expirationPolicy: AUTOMATIC
-  # The frequency to delete the entity types. Defaults to EIGHT_DAYS
+  # The amount of time without receiving telemetry before an entity is deleted. Defaults to EIGHT_DAYS
   expirationTime: EIGHT_DAYS

--- a/docs/example-entity-definition.yml
+++ b/docs/example-entity-definition.yml
@@ -44,3 +44,10 @@ compositeMetrics:
 goldenTags:
   - tagNameA
   - tagNameB
+
+# Defines whether the entities of this type are automatically deleted and with what frequency
+ttl:
+  # The strategy to follow when indexing the entity type. Defaults to DELETE_BY_QUERY
+  indexStrategy: DELETE_BY_QUERY
+  # The frequency to delete the entity types. Defaults to EIGHT_DAYS
+  deletionFrequency: EIGHT_DAYS

--- a/validator/schemas/entity-schema-v1.json
+++ b/validator/schemas/entity-schema-v1.json
@@ -267,6 +267,38 @@
           }
         ]
       }
+    },
+    "ttl": {
+      "$id": "#/properties/ttl",
+      "type": "object",
+      "title": "TTL for the entity type.",
+      "anyOf": [
+        {
+          "required": [
+            "indexStrategy"
+          ]
+        },
+        {
+          "required": [
+            "deletionFrequency"
+          ]
+        }
+      ],
+      "properties": {
+        "indexStrategy": {
+          "$id": "#/properties/ttl/properties/indexStrategy",
+          "type": "string",
+          "title": "Index Strategy",
+          "enum": ["DELETE_BY_DOCUMENT", "DELETE_BY_QUERY"]
+        },
+        "deletionFrequency": {
+          "$id": "#/properties/ttl/properties/deletionFrequency",
+          "type": "string",
+          "title": "Deletion Frequency",
+          "enum": ["MANUAL", "HOURLY", "DAILY", "EIGHT_DAYS", "QUARTERLY"]
+        }
+      },
+      "additionalProperties": false
     }
   },
   "additionalProperties": false

--- a/validator/schemas/entity-schema-v1.json
+++ b/validator/schemas/entity-schema-v1.json
@@ -272,24 +272,15 @@
       "$id": "#/properties/ttl",
       "type": "object",
       "title": "TTL for the entity type.",
-      "anyOf": [
-        {
-          "required": [
-            "indexStrategy"
-          ]
-        },
-        {
-          "required": [
-            "deletionFrequency"
-          ]
-        }
+      "required": [
+        "deletionStrategy"
       ],
       "properties": {
-        "indexStrategy": {
-          "$id": "#/properties/ttl/properties/indexStrategy",
+        "deletionStrategy": {
+          "$id": "#/properties/ttl/properties/deletionStrategy",
           "type": "string",
-          "title": "Index Strategy",
-          "enum": ["DELETE_BY_DOCUMENT", "DELETE_BY_QUERY"]
+          "title": "Deletion Strategy",
+          "enum": ["AUTOMATIC", "MANUAL"]
         },
         "deletionFrequency": {
           "$id": "#/properties/ttl/properties/deletionFrequency",

--- a/validator/schemas/entity-schema-v1.json
+++ b/validator/schemas/entity-schema-v1.json
@@ -268,25 +268,16 @@
         ]
       }
     },
-    "expiration": {
-      "$id": "#/properties/expiration",
+    "configuration": {
+      "$id": "#/properties/configuration",
       "type": "object",
-      "title": "Expiration for the entity type.",
-      "required": [
-        "expirationPolicy"
-      ],
+      "title": "Configurations for the entity type.",
       "properties": {
-        "expirationPolicy": {
-          "$id": "#/properties/expiration/properties/expirationPolicy",
+        "entityExpirationTime": {
+          "$id": "#/properties/configuration/properties/entityExpirationTime",
           "type": "string",
-          "title": "Expiration Policy",
-          "enum": ["AUTOMATIC", "MANUAL"]
-        },
-        "expirationTime": {
-          "$id": "#/properties/expiration/properties/expirationTime",
-          "type": "string",
-          "title": "Expiration Time",
-          "enum": ["DAILY", "EIGHT_DAYS", "QUARTERLY"]
+          "title": "Entity expiration Time",
+          "enum": ["DAILY", "EIGHT_DAYS", "QUARTERLY", "MANUAL"]
         }
       },
       "additionalProperties": false

--- a/validator/schemas/entity-schema-v1.json
+++ b/validator/schemas/entity-schema-v1.json
@@ -268,24 +268,24 @@
         ]
       }
     },
-    "ttl": {
-      "$id": "#/properties/ttl",
+    "expiration": {
+      "$id": "#/properties/expiration",
       "type": "object",
-      "title": "TTL for the entity type.",
+      "title": "Expiration for the entity type.",
       "required": [
-        "deletionStrategy"
+        "expirationPolicy"
       ],
       "properties": {
-        "deletionStrategy": {
-          "$id": "#/properties/ttl/properties/deletionStrategy",
+        "expirationPolicy": {
+          "$id": "#/properties/expiration/properties/expirationPolicy",
           "type": "string",
-          "title": "Deletion Strategy",
+          "title": "Expiration Policy",
           "enum": ["AUTOMATIC", "MANUAL"]
         },
-        "deletionFrequency": {
-          "$id": "#/properties/ttl/properties/deletionFrequency",
+        "expirationTime": {
+          "$id": "#/properties/expiration/properties/expirationTime",
           "type": "string",
-          "title": "Deletion Frequency",
+          "title": "Expiration Time",
           "enum": ["MANUAL", "HOURLY", "DAILY", "EIGHT_DAYS", "QUARTERLY"]
         }
       },

--- a/validator/schemas/entity-schema-v1.json
+++ b/validator/schemas/entity-schema-v1.json
@@ -286,7 +286,7 @@
           "$id": "#/properties/expiration/properties/expirationTime",
           "type": "string",
           "title": "Expiration Time",
-          "enum": ["MANUAL", "HOURLY", "DAILY", "EIGHT_DAYS", "QUARTERLY"]
+          "enum": ["DAILY", "EIGHT_DAYS", "QUARTERLY"]
         }
       },
       "additionalProperties": false


### PR DESCRIPTION
### Relevant information

Added an optional TTL configuration section, replacing indexStrategy for deletionStrategy, since I think that it's easier to understand. We can also default the deletionFrequency based on the deletionStrategy, so I modified that as well. 

If we do want to keep our original naming convention I can just revert the second commit, so just let me know what you think. 
