### PR TITLE
Add synthesis rules for INFRA-CONTAINER

### DIFF
--- a/definitions/infra-container/definition.yml
+++ b/definitions/infra-container/definition.yml
@@ -1,6 +1,8 @@
 domain: INFRA
 type: CONTAINER
 
+# TODO: missing conditions to match on k8s containers, waiting until
+#       we add support for multiple telemetry sources.
 synthesis:
   identifier: entity.id
   name: docker.name

--- a/definitions/infra-container/definition.yml
+++ b/definitions/infra-container/definition.yml
@@ -1,8 +1,26 @@
 domain: INFRA
 type: CONTAINER
+
+synthesis:
+  identifier: entity.id
+  name: docker.name
+  encodeIdentifierInGUID: true
+
+  conditions:
+    - attribute: docker.containerId
+
+  tags:
+    - container.state
+    - docker.state
+    - docker.containerId
+    - newrelic.integrationName
+    - newrelic.integrationVersion
+    - newrelic.agentVersion
+
 goldenTags:
 - environment
 - container.state
+
 compositeMetrics:
   goldenMetrics:
   - golden_metrics.yml


### PR DESCRIPTION
* Missing aliasing one tag (docker.state should create container.state).
  We have to add this feature to the config files.
* Missing defining a second set of rules for Kubernetes containers,
  which needs adding the multiple-telemetry support feature to these
  files.

This will however allow us to start seeing some synthesized containers.

Signed-off-by: Galo Navarro <gnavarro@newrelic.com>

### Relevant information

Describe what you have done and any details that you think are relevant or that you might want to discuss with us. 

### Checklist

* [x] I've read the guidelines and understand the acceptance criteria.
* [x] The value of the attribute marked as `identifier` will be unique and valid. 
* [x] I've confirmed that my entity type wasn't already defined. If it is I'm providing an
 explanation above.
