### PR TITLE
Migrate vsphere summary metrics

### DIFF
--- a/definitions/infra-azureappserviceplan/definition.yml
+++ b/definitions/infra-azureappserviceplan/definition.yml
@@ -1,2 +1,5 @@
 domain: INFRA
 type: AZUREAPPSERVICEPLAN
+compositeMetrics:
+  summaryMetrics:
+  - ./summary_metrics.yml

--- a/definitions/infra-azureappserviceplan/summary_metrics.yml
+++ b/definitions/infra-azureappserviceplan/summary_metrics.yml
@@ -1,0 +1,19 @@
+providerAccountName:
+  tag:
+    key: providerAccountName
+  title: Azure Account
+  unit: STRING
+cpuUsage:
+  query:
+    eventId: entityGuid
+    select: average(`cpuPercent.Average`)
+    from: AzureAppServiceWebAppSample
+  unit: PERCENTAGE
+  title: CPU Usage
+memoryUsage:
+  query:
+    eventId: entityGuid
+    select: average(`memoryPercent.Average`)
+    from: AzureAppServiceWebAppSample
+  unit: PERCENTAGE
+  title: Memory Usage

--- a/definitions/infra-gcpkubernetescontainer/definition.yml
+++ b/definitions/infra-gcpkubernetescontainer/definition.yml
@@ -1,2 +1,5 @@
 domain: INFRA
 type: GCPKUBERNETESCONTAINER
+compositeMetrics:
+  summaryMetrics:
+  - ./summary_metrics.yml

--- a/definitions/infra-gcpkubernetescontainer/summary_metrics.yml
+++ b/definitions/infra-gcpkubernetescontainer/summary_metrics.yml
@@ -1,0 +1,19 @@
+providerAccountName:
+  tag:
+    key: providerAccountName
+  title: GCP Account
+  unit: STRING
+cpuUsage:
+  query:
+    eventId: entityGuid
+    select: average(`container.cpu.usageTime`)
+    from: GcpKubernetesContainerSample
+  unit: SECONDS
+  title: Cumulative CPU utilization over 60s
+memoryUsage:
+  query:
+    eventId: entityGuid
+    select: average(`container.memory.usedBytes`)
+    from: GcpKubernetesContainerSample
+  unit: BYTES
+  title: Memory Usage

--- a/definitions/infra-gcpkubernetesnode/definition.yml
+++ b/definitions/infra-gcpkubernetesnode/definition.yml
@@ -1,2 +1,5 @@
 domain: INFRA
 type: GCPKUBERNETESNODE
+compositeMetrics:
+  summaryMetrics:
+  - ./summary_metrics.yml

--- a/definitions/infra-gcpkubernetesnode/summary_metrics.yml
+++ b/definitions/infra-gcpkubernetesnode/summary_metrics.yml
@@ -1,0 +1,19 @@
+providerAccountName:
+  tag:
+    key: providerAccountName
+  title: GCP Account
+  unit: STRING
+cpuUsage:
+  query:
+    eventId: entityGuid
+    select: average(`node.cpu.coreUsageTime`)
+    from: GcpKubernetesNodeSample
+  unit: SECONDS
+  title: Cumulative CPU utilization over 60s
+memoryUsage:
+  query:
+    eventId: entityGuid
+    select: average(`node.memory.usedBytes`)
+    from: GcpKubernetesNodeSample
+  unit: BYTES
+  title: Memory Usage

--- a/definitions/infra-vspherecluster/definition.yml
+++ b/definitions/infra-vspherecluster/definition.yml
@@ -4,3 +4,5 @@ goldenTags: []
 compositeMetrics:
   goldenMetrics:
   - golden_metrics.yml
+  summaryMetrics:
+  - ./summary_metrics.yml

--- a/definitions/infra-vspherecluster/summary_metrics.yml
+++ b/definitions/infra-vspherecluster/summary_metrics.yml
@@ -1,0 +1,21 @@
+effectiveHosts:
+  query:
+    eventId: entityGuid
+    select: latest(`effectiveHosts`)
+    from: VSphereClusterSample
+  unit: COUNT
+  title: Effective hosts
+hostsCount:
+  query:
+    eventId: entityGuid
+    select: latest(`hosts`)
+    from: VSphereClusterSample
+  unit: COUNT
+  title: Hosts count
+overallStatus:
+  query:
+    eventId: entityGuid
+    select: latest(`overallStatus`)
+    from: VSphereClusterSample
+  unit: COUNT
+  title: Overall status

--- a/definitions/infra-vspheredatacenter/definition.yml
+++ b/definitions/infra-vspheredatacenter/definition.yml
@@ -4,3 +4,5 @@ goldenTags: []
 compositeMetrics:
   goldenMetrics:
   - golden_metrics.yml
+  summaryMetrics:
+  - ./summary_metrics.yml

--- a/definitions/infra-vspheredatacenter/summary_metrics.yml
+++ b/definitions/infra-vspheredatacenter/summary_metrics.yml
@@ -1,0 +1,21 @@
+cpuUtilization:
+  query:
+    eventId: entityGuid
+    select: average(`cpu.overallUsagePercentage`)
+    from: VSphereDatacenterSample
+  unit: PERCENTAGE
+  title: CPU Utilization
+memUsage:
+  query:
+    eventId: entityGuid
+    select: (average(`mem.usage`)) * 1024 * 1204
+    from: VSphereDatacenterSample
+  unit: BYTES
+  title: Memory usage
+overallStatus:
+  query:
+    eventId: entityGuid
+    select: latest(`overallStatus`)
+    from: VSphereDatacenterSample
+  unit: COUNT
+  title: Overall status

--- a/definitions/infra-vspheredatastore/definition.yml
+++ b/definitions/infra-vspheredatastore/definition.yml
@@ -4,3 +4,5 @@ goldenTags: []
 compositeMetrics:
   goldenMetrics:
   - golden_metrics.yml
+  summaryMetrics:
+  - ./summary_metrics.yml

--- a/definitions/infra-vspheredatastore/summary_metrics.yml
+++ b/definitions/infra-vspheredatastore/summary_metrics.yml
@@ -1,0 +1,21 @@
+hostsCount:
+  query:
+    eventId: entityGuid
+    select: latest(`hostCount`)
+    from: VSphereDatastoreSample
+  unit: COUNT
+  title: Hosts count
+vmCount:
+  query:
+    eventId: entityGuid
+    select: latest(`vmCount`)
+    from: VSphereDatastoreSample
+  unit: COUNT
+  title: Virtual Machines count
+accessible:
+  query:
+    eventId: entityGuid
+    select: latest(`accessible`)
+    from: VSphereDatastoreSample
+  unit: COUNT
+  title: Accessible

--- a/definitions/infra-vspherehost/definition.yml
+++ b/definitions/infra-vspherehost/definition.yml
@@ -4,3 +4,5 @@ goldenTags: []
 compositeMetrics:
   goldenMetrics:
   - golden_metrics.yml
+  summaryMetrics:
+  - ./summary_metrics.yml

--- a/definitions/infra-vspherehost/summary_metrics.yml
+++ b/definitions/infra-vspherehost/summary_metrics.yml
@@ -1,0 +1,28 @@
+cpuUtilization:
+  query:
+    eventId: entityGuid
+    select: average(`cpu.percent`)
+    from: VSphereHostSample
+  unit: PERCENTAGE
+  title: CPU Utilization
+memoryUtilization:
+  query:
+    eventId: entityGuid
+    select: average(`mem.usage`/`mem.size`)*100
+    from: VSphereHostSample
+  unit: PERCENTAGE
+  title: Memory Utilization
+vmCount:
+  query:
+    eventId: entityGuid
+    select: latest(`vmCount`)
+    from: VSphereHostSample
+  unit: COUNT
+  title: Virtual Machines count
+connectionState:
+  query:
+    eventId: entityGuid
+    select: latest(`connectionState`)
+    from: VSphereHostSample
+  unit: COUNT
+  title: Connection State

--- a/definitions/infra-vsphereresourcepool/definition.yml
+++ b/definitions/infra-vsphereresourcepool/definition.yml
@@ -4,3 +4,5 @@ goldenTags: []
 compositeMetrics:
   goldenMetrics:
   - golden_metrics.yml
+  summaryMetrics:
+  - ./summary_metrics.yml

--- a/definitions/infra-vsphereresourcepool/summary_metrics.yml
+++ b/definitions/infra-vsphereresourcepool/summary_metrics.yml
@@ -1,0 +1,21 @@
+vmCount:
+  query:
+    eventId: entityGuid
+    select: latest(`vmCount`)
+    from: VSphereResourcePoolSample
+  unit: COUNT
+  title: Virtual machines count
+memSwapped:
+  query:
+    eventId: entityGuid
+    select: (average(`mem.swapped`)) * 1024 * 1204
+    from: VSphereResourcePoolSample
+  unit: BYTES
+  title: Memory swapped
+overallStatus:
+  query:
+    eventId: entityGuid
+    select: latest(`overallStatus`)
+    from: VSphereResourcePoolSample
+  unit: COUNT
+  title: Overall status

--- a/definitions/infra-vspherevm/definition.yml
+++ b/definitions/infra-vspherevm/definition.yml
@@ -4,3 +4,5 @@ goldenTags: []
 compositeMetrics:
   goldenMetrics:
   - golden_metrics.yml
+  summaryMetrics:
+  - ./summary_metrics.yml

--- a/definitions/infra-vspherevm/summary_metrics.yml
+++ b/definitions/infra-vspherevm/summary_metrics.yml
@@ -1,0 +1,35 @@
+cpuUtilization:
+  query:
+    eventId: entityGuid
+    select: average(`cpu.hostUsagePercent`)
+    from: VSphereVmSample
+  unit: PERCENTAGE
+  title: CPU Utilization
+memoryUtilization:
+  query:
+    eventId: entityGuid
+    select: average(`mem.usage`/`mem.size`)*100
+    from: VSphereVmSample
+  unit: PERCENTAGE
+  title: Memory Utilization
+cpuAllocationlimit:
+  query:
+    eventId: entityGuid
+    select: (latest(`cpu.allocationLimit`)) * 1000 * 1000
+    from: VSphereVmSample
+  unit: HERTZ
+  title: CPU Allocation Limit
+powerState:
+  query:
+    eventId: entityGuid
+    select: latest(`powerState`)
+    from: VSphereVmSample
+  unit: COUNT
+  title: Power State
+connectionState:
+  query:
+    eventId: entityGuid
+    select: latest(`connectionState`)
+    from: VSphereVmSample
+  unit: COUNT
+  title: Connection State


### PR DESCRIPTION
### Relevant information

Move the vsphere summary metrics. These metrics where pointing to wrong entity types in the past and hence why there were not migrated.

### Checklist

* [ ] I've read the guidelines and understand the acceptance criteria.
* [ ] The value of the attribute marked as `identifier` will be unique and valid. 
* [ ] I've confirmed that my entity type wasn't already defined. If it is I'm providing an
 explanation above.
