### PR TITLE
Add summary metrics for GCP Cloud Function

### DIFF
--- a/definitions/infra-gcpcloudfunction/definition.yml
+++ b/definitions/infra-gcpcloudfunction/definition.yml
@@ -1,2 +1,6 @@
 domain: INFRA
 type: GCPCLOUDFUNCTION
+
+compositeMetrics:
+   summaryMetrics:
+      - summary_metrics.yml

--- a/definitions/infra-gcpcloudfunction/summary_metrics.yml
+++ b/definitions/infra-gcpcloudfunction/summary_metrics.yml
@@ -1,0 +1,21 @@
+providerAccountName:
+  tag:
+    key: providerAccountName
+  title: GCP Account
+  unit: STRING
+executions:
+  query:
+    eventId: entityGuid
+    eventObjectId: ENTITY_GUID
+    select: sum(`function.Executions`)
+    from: GcpCloudFunctionSample
+  unit: COUNT
+  title: Executions
+errorRate:
+  query:
+    eventId: entityGuid
+    eventObjectId: ENTITY_GUID
+    select: filter(sum(`function.Executions`), WHERE status != 'ok') * 100 / sum(`function.Executions`)
+    from: GcpCloudFunctionSample
+  unit: PERCENTAGE
+  title: Error rate


### PR DESCRIPTION
### Relevant information

Another poor entity type that we missed to migrate its summary metrics.

### Checklist

* [ ] I've read the guidelines and understand the acceptance criteria.
* [ ] The value of the attribute marked as `identifier` will be unique and valid. 
* [ ] I've confirmed that my entity type wasn't already defined. If it is I'm providing an
 explanation above.
