### PR TITLE
Changing the order of application metrics

### DIFF
--- a/definitions/apm-application/golden_metrics.yml
+++ b/definitions/apm-application/golden_metrics.yml
@@ -1,3 +1,9 @@
+responseTimeMs:
+  title: Response time (ms)
+  query:
+    select: average(newrelic.timeslice.value)
+    where: metricTimesliceName in ('HttpDispatcher', 'OtherTransaction/all')
+    facet: appName
 throughput:
   title: Throughput
   query:
@@ -10,10 +16,4 @@ errorRate:
     select: filter(count(newrelic.timeslice.value), where metricTimesliceName = 'Errors/all')
       / (filter(count(newrelic.timeslice.value), where metricTimesliceName in ('HttpDispatcher',
       'OtherTransaction/all'))) * 100
-    facet: appName
-responseTimeMs:
-  title: Response time (ms)
-  query:
-    select: average(newrelic.timeslice.value)
-    where: metricTimesliceName in ('HttpDispatcher', 'OtherTransaction/all')
     facet: appName


### PR DESCRIPTION
Changing the order of the applications metrics to align with the service summary page.

### Checklist

* [X] I've read the guidelines and understand the acceptance criteria.
* [X] The value of the attribute marked as `identifier` will be unique and valid. 
* [X] I've confirmed that my entity type wasn't already defined. If it is I'm providing an
 explanation above.
