### PR TITLE
remove invalid options

### DIFF
--- a/definitions/infra-gcpcloudfunction/summary_metrics.yml
+++ b/definitions/infra-gcpcloudfunction/summary_metrics.yml
@@ -6,7 +6,6 @@ providerAccountName:
 executions:
   query:
     eventId: entityGuid
-    eventObjectId: ENTITY_GUID
     select: sum(`function.Executions`)
     from: GcpCloudFunctionSample
   unit: COUNT
@@ -14,7 +13,6 @@ executions:
 errorRate:
   query:
     eventId: entityGuid
-    eventObjectId: ENTITY_GUID
     select: filter(sum(`function.Executions`), WHERE status != 'ok') * 100 / sum(`function.Executions`)
     from: GcpCloudFunctionSample
   unit: PERCENTAGE


### PR DESCRIPTION
### Relevant information

This option should not be used in general. But when used the value is DOMAIN_IDS or ENTITY_GUIDS

### Checklist

* [ ] I've read the guidelines and understand the acceptance criteria.
* [ ] The value of the attribute marked as `identifier` will be unique and valid. 
* [ ] I've confirmed that my entity type wasn't already defined. If it is I'm providing an
 explanation above.
