### PR TITLE
Encode EXT-REDIS identifier

### DIFF
--- a/definitions/ext-redis/definition.yml
+++ b/definitions/ext-redis/definition.yml
@@ -3,6 +3,7 @@ type: REDIS
 synthesis:
   identifier: targetName
   name: targetName
+  encodeIdentifierInGUID: true
 
   conditions:
     - attribute: metricName


### PR DESCRIPTION
Since we're using the cluster name as domainId, the full GUID tends to
exceed the max size.  Use the encoding option to avoid this.

Signed-off-by: Galo Navarro <gnavarro@newrelic.com>

### Relevant information

Describe what you have done and any details that you think are relevant or that you might want to discuss with us. 

### Checklist

* [x] I've read the guidelines and understand the acceptance criteria.
* [x] The value of the attribute marked as `identifier` will be unique and valid. 
* [x] I've confirmed that my entity type wasn't already defined. If it is I'm providing an
 explanation above.
