### PR TITLE
Update golden metrics for INFRA-CONTAINER

### DIFF
--- a/definitions/infra-container/golden_metrics.yml
+++ b/definitions/infra-container/golden_metrics.yml
@@ -1,20 +1,21 @@
 cpuUsage:
   title: CPU usage (cores)
   query:
-    select: max(docker.container.cpuUsedCores) or max(k8s.container.cpuUsedCores)
-      as 'CPU used cores'
-cpuUtilization:
-  title: CPU Utilization (%)
-  query:
-    select: max(docker.container.cpuPercent) or max(k8s.container.cpuCoresUtilization)
-      AS 'CPU Utilization (%)'
+    select: max(ContainerSample.cpuUsedCores) or max(K8sContainerSample.cpuUsedCores)
+    from: ContainerSample,K8sContainerSample
+    facet: entityName
+    eventId: entityGuid
 memoryUsage:
   title: Memory usage (bytes)
   query:
-    select: max(docker.container.memoryUsageBytes) or max(k8s.container.memoryUtilization)
-      AS 'Memory used (bytes)'
+    select: max(ContainerSample.memoryUsageBytes) or max(K8sContainerSample.memoryWorkingSetBytes)
+    from: ContainerSample,K8sContainerSample
+    facet: entityName
+    eventId: entityGuid
 storageUsage:
   title: Storage usage (bytes)
   query:
-    select: max(docker.container.ioTotalBytes) or max(k8s.container.fsUsedPercent)
-      AS 'Storage used (bytes)'
+    select: max(ContainerSample.ioTotalBytes) or max(K8sContainerSample.fsUsedBytes)
+    from: ContainerSample,K8sContainerSample
+    facet: entityName
+    eventId: entityGuid


### PR DESCRIPTION
### Relevant information

- Update queries to use sample events instead of the new Metric event
type. There are still some services consuming these queries that can't
handle the new format.
- Remove the `as` clause in the select fields.
- Fix the queries to use the same kind of metrics between different data
sources.

@naxhh @IreneMLC do we support the double event types syntax, ex: `from: ContainerSample, K8sContainerSample` ?

That's supported by nrql and nrdb, I hope we also support it here.

Thank you

### Checklist

* [ ] I've read the guidelines and understand the acceptance criteria.
* [ ] The value of the attribute marked as `identifier` will be unique and valid. 
* [ ] I've confirmed that my entity type wasn't already defined. If it is I'm providing an
 explanation above.
