### PR TITLE
Tags definitions are now a map instead of a list

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,13 @@ During synthesis, the tags will be created using the attribute name as key and i
 
 If some of the tags' attributes are not present on the telemetry message received, the entity will still be synthesized with the available tags (if any).
 
+```yaml
+  tags:
+    attributeNameB:
+      multiValue: false # declare if the value for this tag should be a list of string values (accumulated) or a single value (replaced). defaults to true
+    attributeNameC:
+```
+
 #### Golden tags
 
 The `goldenTags` field accepts an array of tag-keys which are considered the most important for the entity's DOMAIN and TYPE, 

--- a/definitions/ext-fastly_pop/definition.yml
+++ b/definitions/ext-fastly_pop/definition.yml
@@ -13,7 +13,7 @@ synthesis:
 #      value: value
 
   tags:
-    - fastly_region
+    fastly_region:
 
 # Template that can be used to generate a dashboard for the entity.
 # dashboardTemplates:

--- a/definitions/ext-redis/definition.yml
+++ b/definitions/ext-redis/definition.yml
@@ -10,8 +10,8 @@ synthesis:
       prefix: redis_
 
   tags:
-    - clusterName
-    - targetName
+    clusterName:
+    targetName:
 
 compositeMetrics:
   goldenMetrics:

--- a/definitions/ext-tinyproxy/definition.yml
+++ b/definitions/ext-tinyproxy/definition.yml
@@ -12,7 +12,7 @@ synthesis:
       prefix: tinyproxy_
 
   tags:
-    - instrumentation.name
+    instrumentation.name:
 
 dashboardTemplates: 
   - dashboard.json

--- a/definitions/infra-container/definition.yml
+++ b/definitions/infra-container/definition.yml
@@ -12,12 +12,12 @@ synthesis:
     - attribute: docker.containerId
 
   tags:
-    - container.state
-    - docker.state
-    - docker.containerId
-    - newrelic.integrationName
-    - newrelic.integrationVersion
-    - newrelic.agentVersion
+    container.state:
+    docker.state:
+    docker.containerId:
+    newrelic.integrationName:
+    newrelic.integrationVersion:
+    newrelic.agentVersion:
 
 goldenTags:
 - environment

--- a/definitions/infra-etcd_cluster/definition.yml
+++ b/definitions/infra-etcd_cluster/definition.yml
@@ -7,13 +7,13 @@ synthesis:
   - attribute: metricName
     prefix: etcd_
   tags:
-  - label.topology.kubernetes.io/region
-  - label.topology.kubernetes.io/zone
-  - label.eks.amazonaws.com/compute-type
-  - k8s.cluster.name
-  - label.kubernetes.io/arch
-  - label.kubernetes.io/hostname
-  - label.kubernetes.io/os
+    'label.topology.kubernetes.io/region':
+    'label.topology.kubernetes.io/zone':
+    'label.eks.amazonaws.com/compute-type':
+    'k8s.cluster.name':
+    'label.kubernetes.io/arch':
+    'label.kubernetes.io/hostname':
+    'label.kubernetes.io/os':
 dashboardTemplates:
 - dashboard.json
 goldenTags:

--- a/definitions/infra-kubernetes_apiserver/definition.yml
+++ b/definitions/infra-kubernetes_apiserver/definition.yml
@@ -8,13 +8,13 @@ synthesis:
   - attribute: metricName
     prefix: apiserver_
   tags:
-  - label.topology.kubernetes.io/region
-  - label.topology.kubernetes.io/zone
-  - label.eks.amazonaws.com/compute-type
-  - k8s.cluster.name
-  - label.kubernetes.io/arch
-  - label.kubernetes.io/hostname
-  - label.kubernetes.io/os
+    'label.topology.kubernetes.io/region':
+    'label.topology.kubernetes.io/zone':
+    'label.eks.amazonaws.com/compute-type':
+    'k8s.cluster.name':
+    'label.kubernetes.io/arch':
+    'label.kubernetes.io/hostname':
+    'label.kubernetes.io/os':
 goldenTags:
 - label.kubernetes.io/os
 compositeMetrics:

--- a/docs/example-entity-definition.yml
+++ b/docs/example-entity-definition.yml
@@ -24,8 +24,8 @@ synthesis:
 
   # Tags associated with the entity that can be extracted from the telemetry attributes.
   tags:
-    - attributeNameB
-    - attributeNameC
+    attributeNameB:
+    attributeNameC:
 
 # Template that can be used to generate a dashboard for the entity.
 dashboardTemplates:

--- a/validator/schemas/entity-schema-v1.json
+++ b/validator/schemas/entity-schema-v1.json
@@ -159,7 +159,7 @@
         },
         "tags": {
           "$id": "#/properties/tags",
-          "type": "array",
+          "type": "object",
           "title": "An array of tags.",
           "description": "Tags associated to the entity that can be extracted from the metrics information received.",
           "examples": [
@@ -174,8 +174,19 @@
             "anyOf": [
               {
                 "$id": "#/properties/tags/items/anyOf/0",
-                "type": "string",
-                "title": "Reference to a tag extracted from metrics"
+                "type": "object",
+                "title": "Tag configuration",
+                "description": "The configuration of the tag being synthesized",
+                "examples": [
+                  {"multiValue": "false"}
+                ],
+                "properties": {
+                  "multiValue": {
+                    "$id": "#/properties/tags/items/anyOf/0/properties/multiValue",
+                    "type": "boolean",
+                    "title": "If the tag should allow a list of string values or a single string value"
+                  }
+                }
               }
             ]
           }


### PR DESCRIPTION
### Relevant information

In future we will need to add behavior to the tags. For example single value tags as this PR introduces. Aliases for tags, etc..

In order to do that we need to allow a broad configuration to the tags instead of just a simple string.

### Checklist

* [ ] I've read the guidelines and understand the acceptance criteria.
* [ ] The value of the attribute marked as `identifier` will be unique and valid. 
* [ ] I've confirmed that my entity type wasn't already defined. If it is I'm providing an
 explanation above.
