### PR TITLE
fix: Fix typo in infra.awsnlb.failedClientNlbTlsHandshakes

### DIFF
--- a/definitions/infra-awsnlb/golden_metrics.yml
+++ b/definitions/infra-awsnlb/golden_metrics.yml
@@ -1,7 +1,7 @@
 failedClientNlbTlsHandshakes:
   title: Failed client-NLB TLS handshakes
   query:
-    select: rate((sum(provider.clientTlsNegotiationErrorCount.Sum),1 minute)
+    select: rate(sum(provider.clientTlsNegotiationErrorCount.Sum),1 minute)
     from: LoadBalancerSample
     where: provider='Nlb'
     eventId: entityGuid


### PR DESCRIPTION
There is one too many open paren's in the select clause.

### Relevant information

Deleted extraneous `(`

### Checklist

* [x] I've read the guidelines and understand the acceptance criteria.
* [ ] The value of the attribute marked as `identifier` will be unique and valid. 
* [ ] I've confirmed that my entity type wasn't already defined. If it is I'm providing an
 explanation above.
