### PR TITLE
fix: Added missing open parens

### DIFF
--- a/definitions/infra-awskinesisdeliverystream/golden_metrics.yml
+++ b/definitions/infra-awskinesisdeliverystream/golden_metrics.yml
@@ -26,7 +26,7 @@ putRecordThroughput:
 getRecordsThroughput:
   title: Records out per sec
   query:
-    select: rate(sum(`provider.deliveryToElasticsearchRecords.Sum`) + sum(`provider.deliveryToS3Records.Sum`)
+    select: rate((sum(`provider.deliveryToElasticsearchRecords.Sum`) + sum(`provider.deliveryToS3Records.Sum`)
       + sum(`provider.deliveryToRedshiftRecords.Sum`)), 1 second)
     from: QueueSample
     where: provider='KinesisDeliveryStream'

--- a/definitions/infra-awskinesisdeliverystream/golden_metrics.yml
+++ b/definitions/infra-awskinesisdeliverystream/golden_metrics.yml
@@ -9,7 +9,7 @@ putThroughput:
 getThroughput:
   title: Bytes out per sec
   query:
-    select: rate(sum(`provider.deliveryToElasticsearchBytes.Sum`) + sum(`provider.deliveryToS3Bytes.Sum`)
+    select: rate((sum(`provider.deliveryToElasticsearchBytes.Sum`) + sum(`provider.deliveryToS3Bytes.Sum`)
       + sum(`provider.deliveryToRedshiftBytes.Sum`)), 1 second)
     from: QueueSample
     where: provider='KinesisDeliveryStream'


### PR DESCRIPTION
Added missing open paren in the select clause of `infra.awskinesisdeliverystream.getRecordsThroughput` and `infra.awskinesisdeliverystream.getThroughput`  

### Relevant information

Added missing `(`

### Checklist

* [x] I've read the guidelines and understand the acceptance criteria.
* [ ] The value of the attribute marked as `identifier` will be unique and valid. 
* [ ] I've confirmed that my entity type wasn't already defined. If it is I'm providing an
 explanation above.
