### PR TITLE
Migrate entity configurations

### DIFF
--- a/definitions/apm-application/definition.yml
+++ b/definitions/apm-application/definition.yml
@@ -8,3 +8,6 @@ goldenTags:
 compositeMetrics:
   goldenMetrics:
   - golden_metrics.yml
+configuration:
+  entityExpirationTime: QUARTERLY
+  alertable: true

--- a/definitions/browser-application/definition.yml
+++ b/definitions/browser-application/definition.yml
@@ -4,3 +4,6 @@ goldenTags: []
 compositeMetrics:
   goldenMetrics:
   - golden_metrics.yml
+configuration:
+  entityExpirationTime: QUARTERLY
+  alertable: true

--- a/definitions/ext-browser_app/definition.yml
+++ b/definitions/ext-browser_app/definition.yml
@@ -1,10 +1,11 @@
 domain: EXT
 type: BROWSER_APP
-
 synthesis:
   identifier: browserApp.name
   name: browserApp.name
   encodeIdentifierInGUID: true
-
   conditions:
-    - attribute: browserApp.name
+  - attribute: browserApp.name
+configuration:
+  entityExpirationTime: EIGHT_DAYS
+  alertable: false

--- a/definitions/ext-host/definition.yml
+++ b/definitions/ext-host/definition.yml
@@ -1,10 +1,11 @@
 domain: EXT
 type: HOST
-
 synthesis:
   identifier: host
   name: host
   encodeIdentifierInGUID: true
-
   conditions:
-    - attribute: host
+  - attribute: host
+configuration:
+  entityExpirationTime: DAILY
+  alertable: false

--- a/definitions/ext-mobile_app/definition.yml
+++ b/definitions/ext-mobile_app/definition.yml
@@ -1,10 +1,11 @@
 domain: EXT
 type: MOBILE_APP
-
 synthesis:
   identifier: mobileApp.name
   name: mobileApp.name
   encodeIdentifierInGUID: true
-
   conditions:
-    - attribute: mobileApp.name
+  - attribute: mobileApp.name
+configuration:
+  entityExpirationTime: EIGHT_DAYS
+  alertable: false

--- a/definitions/ext-redis/definition.yml
+++ b/definitions/ext-redis/definition.yml
@@ -4,20 +4,19 @@ synthesis:
   identifier: targetName
   name: targetName
   encodeIdentifierInGUID: true
-
   conditions:
-    - attribute: metricName
-      prefix: redis_
-
+  - attribute: metricName
+    prefix: redis_
   tags:
-    clusterName:
-    targetName:
-
+    clusterName: null
+    targetName: null
 compositeMetrics:
   goldenMetrics:
-    - golden_metrics.yml
+  - golden_metrics.yml
   summaryMetrics:
-    - summary_metrics.yml
-
+  - summary_metrics.yml
 dashboardTemplates:
-  - dashboard.json
+- dashboard.json
+configuration:
+  entityExpirationTime: EIGHT_DAYS
+  alertable: true

--- a/definitions/ext-service/definition.yml
+++ b/definitions/ext-service/definition.yml
@@ -1,10 +1,11 @@
 domain: EXT
 type: SERVICE
-
 synthesis:
   identifier: service.name
   name: service.name
   encodeIdentifierInGUID: true
-
   conditions:
-    - attribute: service.name
+  - attribute: service.name
+configuration:
+  entityExpirationTime: EIGHT_DAYS
+  alertable: true

--- a/definitions/infra-apacheserver/definition.yml
+++ b/definitions/infra-apacheserver/definition.yml
@@ -1,11 +1,14 @@
 domain: INFRA
 type: APACHESERVER
 goldenTags:
-  - apache.hostname
-  - apache.port
-  - apache.version
+- apache.hostname
+- apache.port
+- apache.version
 compositeMetrics:
   goldenMetrics:
   - golden_metrics.yml
   summaryMetrics:
   - summary_metrics.yml
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true

--- a/definitions/infra-awsalb/definition.yml
+++ b/definitions/infra-awsalb/definition.yml
@@ -1,20 +1,23 @@
 domain: INFRA
 type: AWSALB
-goldenTags: 
-  - aws.awsRegion
-  - aws.state
-  - aws.type
-  - aws.ipAdressType
-  - aws.dnsName
-  - aws.scheme
-  - aws.accountId
-  - account 
-  - label.Team
-  - label.team
-  - label.env
-  - label.environment
+goldenTags:
+- aws.awsRegion
+- aws.state
+- aws.type
+- aws.ipAdressType
+- aws.dnsName
+- aws.scheme
+- aws.accountId
+- account
+- label.Team
+- label.team
+- label.env
+- label.environment
 compositeMetrics:
   goldenMetrics:
   - golden_metrics.yml
   summaryMetrics:
   - summary_metrics.yml
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true

--- a/definitions/infra-awsalblistener/definition.yml
+++ b/definitions/infra-awsalblistener/definition.yml
@@ -1,2 +1,5 @@
 domain: INFRA
 type: AWSALBLISTENER
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true

--- a/definitions/infra-awsalblistenerrule/definition.yml
+++ b/definitions/infra-awsalblistenerrule/definition.yml
@@ -1,2 +1,5 @@
 domain: INFRA
 type: AWSALBLISTENERRULE
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true

--- a/definitions/infra-awsalbtargetgroup/definition.yml
+++ b/definitions/infra-awsalbtargetgroup/definition.yml
@@ -1,19 +1,22 @@
 domain: INFRA
 type: AWSALBTARGETGROUP
-goldenTags:  
-  - aws.awsRegion
-  - aws.matcher
-  - aws.port
-  - aws.protocol
-  - aws.targetGroupName
-  - aws.accountId
-  - account 
-  - label.Team
-  - label.team
-  - label.env
-  - label.environment
+goldenTags:
+- aws.awsRegion
+- aws.matcher
+- aws.port
+- aws.protocol
+- aws.targetGroupName
+- aws.accountId
+- account
+- label.Team
+- label.team
+- label.env
+- label.environment
 compositeMetrics:
   goldenMetrics:
   - golden_metrics.yml
   summaryMetrics:
   - summary_metrics.yml
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true

--- a/definitions/infra-awsapigatewayapi/definition.yml
+++ b/definitions/infra-awsapigatewayapi/definition.yml
@@ -9,3 +9,6 @@ compositeMetrics:
   - golden_metrics.yml
   summaryMetrics:
   - summary_metrics.yml
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true

--- a/definitions/infra-awsapigatewayresourcewithmetrics/definition.yml
+++ b/definitions/infra-awsapigatewayresourcewithmetrics/definition.yml
@@ -9,3 +9,6 @@ compositeMetrics:
   - golden_metrics.yml
   summaryMetrics:
   - summary_metrics.yml
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true

--- a/definitions/infra-awsapigatewaystage/definition.yml
+++ b/definitions/infra-awsapigatewaystage/definition.yml
@@ -9,3 +9,6 @@ compositeMetrics:
   - golden_metrics.yml
   summaryMetrics:
   - summary_metrics.yml
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true

--- a/definitions/infra-awsappsyncapi/definition.yml
+++ b/definitions/infra-awsappsyncapi/definition.yml
@@ -1,2 +1,5 @@
 domain: INFRA
 type: AWSAPPSYNCAPI
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true

--- a/definitions/infra-awsathenaworkgroup/definition.yml
+++ b/definitions/infra-awsathenaworkgroup/definition.yml
@@ -1,2 +1,5 @@
 domain: INFRA
 type: AWSATHENAWORKGROUP
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true

--- a/definitions/infra-awsautoscalinggroup/definition.yml
+++ b/definitions/infra-awsautoscalinggroup/definition.yml
@@ -9,3 +9,6 @@ compositeMetrics:
   - golden_metrics.yml
   summaryMetrics:
   - summary_metrics.yml
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true

--- a/definitions/infra-awsbillingaccountcost/definition.yml
+++ b/definitions/infra-awsbillingaccountcost/definition.yml
@@ -1,2 +1,5 @@
 domain: INFRA
 type: AWSBILLINGACCOUNTCOST
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true

--- a/definitions/infra-awsbillingaccountservicecost/definition.yml
+++ b/definitions/infra-awsbillingaccountservicecost/definition.yml
@@ -1,2 +1,5 @@
 domain: INFRA
 type: AWSBILLINGACCOUNTSERVICECOST
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true

--- a/definitions/infra-awsbillingbudget/definition.yml
+++ b/definitions/infra-awsbillingbudget/definition.yml
@@ -1,2 +1,5 @@
 domain: INFRA
 type: AWSBILLINGBUDGET
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true

--- a/definitions/infra-awsbillingservicecost/definition.yml
+++ b/definitions/infra-awsbillingservicecost/definition.yml
@@ -1,2 +1,5 @@
 domain: INFRA
 type: AWSBILLINGSERVICECOST
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true

--- a/definitions/infra-awscloudfrontdistribution/definition.yml
+++ b/definitions/infra-awscloudfrontdistribution/definition.yml
@@ -9,3 +9,6 @@ compositeMetrics:
   - golden_metrics.yml
   summaryMetrics:
   - summary_metrics.yml
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true

--- a/definitions/infra-awscloudtrail/definition.yml
+++ b/definitions/infra-awscloudtrail/definition.yml
@@ -1,2 +1,5 @@
 domain: INFRA
 type: AWSCLOUDTRAIL
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true

--- a/definitions/infra-awscognitouserpool/definition.yml
+++ b/definitions/infra-awscognitouserpool/definition.yml
@@ -1,2 +1,5 @@
 domain: INFRA
 type: AWSCOGNITOUSERPOOL
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true

--- a/definitions/infra-awsconnectcontactflow/definition.yml
+++ b/definitions/infra-awsconnectcontactflow/definition.yml
@@ -1,2 +1,5 @@
 domain: INFRA
 type: AWSCONNECTCONTACTFLOW
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true

--- a/definitions/infra-awsconnectinstance/definition.yml
+++ b/definitions/infra-awsconnectinstance/definition.yml
@@ -1,2 +1,5 @@
 domain: INFRA
 type: AWSCONNECTINSTANCE
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true

--- a/definitions/infra-awsconnectqueue/definition.yml
+++ b/definitions/infra-awsconnectqueue/definition.yml
@@ -1,2 +1,5 @@
 domain: INFRA
 type: AWSCONNECTQUEUE
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true

--- a/definitions/infra-awsdirectconnectconnection/definition.yml
+++ b/definitions/infra-awsdirectconnectconnection/definition.yml
@@ -1,2 +1,5 @@
 domain: INFRA
 type: AWSDIRECTCONNECTCONNECTION
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true

--- a/definitions/infra-awsdocdbcluster/definition.yml
+++ b/definitions/infra-awsdocdbcluster/definition.yml
@@ -9,3 +9,6 @@ compositeMetrics:
   - golden_metrics.yml
   summaryMetrics:
   - summary_metrics.yml
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true

--- a/definitions/infra-awsdocdbclusterbyrole/definition.yml
+++ b/definitions/infra-awsdocdbclusterbyrole/definition.yml
@@ -9,3 +9,6 @@ compositeMetrics:
   - golden_metrics.yml
   summaryMetrics:
   - summary_metrics.yml
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true

--- a/definitions/infra-awsdocdbinstance/definition.yml
+++ b/definitions/infra-awsdocdbinstance/definition.yml
@@ -9,3 +9,6 @@ compositeMetrics:
   - golden_metrics.yml
   summaryMetrics:
   - summary_metrics.yml
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true

--- a/definitions/infra-awsdynamodbglobalsecondaryindex/definition.yml
+++ b/definitions/infra-awsdynamodbglobalsecondaryindex/definition.yml
@@ -7,6 +7,9 @@ goldenTags:
 - aws.indexStatus
 compositeMetrics:
   goldenMetrics:
-  - golden_metrics.yml  
+  - golden_metrics.yml
   summaryMetrics:
   - summary_metrics.yml
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true

--- a/definitions/infra-awsdynamodbregion/definition.yml
+++ b/definitions/infra-awsdynamodbregion/definition.yml
@@ -6,3 +6,6 @@ goldenTags:
 compositeMetrics:
   goldenMetrics:
   - golden_metrics.yml
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true

--- a/definitions/infra-awsdynamodbtable/definition.yml
+++ b/definitions/infra-awsdynamodbtable/definition.yml
@@ -10,3 +10,6 @@ compositeMetrics:
   - golden_metrics.yml
   summaryMetrics:
   - summary_metrics.yml
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true

--- a/definitions/infra-awsebsvolume/definition.yml
+++ b/definitions/infra-awsebsvolume/definition.yml
@@ -8,3 +8,6 @@ compositeMetrics:
   - golden_metrics.yml
   summaryMetrics:
   - summary_metrics.yml
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true

--- a/definitions/infra-awsecscluster/definition.yml
+++ b/definitions/infra-awsecscluster/definition.yml
@@ -9,3 +9,6 @@ compositeMetrics:
   - golden_metrics.yml
   summaryMetrics:
   - summary_metrics.yml
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true

--- a/definitions/infra-awsecsservice/definition.yml
+++ b/definitions/infra-awsecsservice/definition.yml
@@ -12,3 +12,6 @@ compositeMetrics:
   - golden_metrics.yml
   summaryMetrics:
   - summary_metrics.yml
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true

--- a/definitions/infra-awsefsfilesystem/definition.yml
+++ b/definitions/infra-awsefsfilesystem/definition.yml
@@ -9,3 +9,6 @@ compositeMetrics:
   - golden_metrics.yml
   summaryMetrics:
   - summary_metrics.yml
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true

--- a/definitions/infra-awselasticachememcachedcluster/definition.yml
+++ b/definitions/infra-awselasticachememcachedcluster/definition.yml
@@ -11,3 +11,6 @@ compositeMetrics:
   - golden_metrics.yml
   summaryMetrics:
   - summary_metrics.yml
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true

--- a/definitions/infra-awselasticachememcachednode/definition.yml
+++ b/definitions/infra-awselasticachememcachednode/definition.yml
@@ -11,3 +11,6 @@ compositeMetrics:
   - golden_metrics.yml
   summaryMetrics:
   - summary_metrics.yml
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true

--- a/definitions/infra-awselasticacherediscluster/definition.yml
+++ b/definitions/infra-awselasticacherediscluster/definition.yml
@@ -11,3 +11,6 @@ compositeMetrics:
   - golden_metrics.yml
   summaryMetrics:
   - summary_metrics.yml
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true

--- a/definitions/infra-awselasticacheredisnode/definition.yml
+++ b/definitions/infra-awselasticacheredisnode/definition.yml
@@ -11,3 +11,6 @@ compositeMetrics:
   - golden_metrics.yml
   summaryMetrics:
   - summary_metrics.yml
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true

--- a/definitions/infra-awselasticbeanstalkenvironment/definition.yml
+++ b/definitions/infra-awselasticbeanstalkenvironment/definition.yml
@@ -11,3 +11,6 @@ compositeMetrics:
   - golden_metrics.yml
   summaryMetrics:
   - summary_metrics.yml
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true

--- a/definitions/infra-awselasticbeanstalkinstance/definition.yml
+++ b/definitions/infra-awselasticbeanstalkinstance/definition.yml
@@ -11,3 +11,6 @@ compositeMetrics:
   - golden_metrics.yml
   summaryMetrics:
   - summary_metrics.yml
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true

--- a/definitions/infra-awselasticmapreducecluster/definition.yml
+++ b/definitions/infra-awselasticmapreducecluster/definition.yml
@@ -9,3 +9,6 @@ compositeMetrics:
   - golden_metrics.yml
   summaryMetrics:
   - summary_metrics.yml
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true

--- a/definitions/infra-awselasticsearchcluster/definition.yml
+++ b/definitions/infra-awselasticsearchcluster/definition.yml
@@ -9,3 +9,6 @@ compositeMetrics:
   - golden_metrics.yml
   summaryMetrics:
   - summary_metrics.yml
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true

--- a/definitions/infra-awselasticsearchinstance/definition.yml
+++ b/definitions/infra-awselasticsearchinstance/definition.yml
@@ -1,2 +1,5 @@
 domain: INFRA
 type: AWSELASTICSEARCHINSTANCE
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true

--- a/definitions/infra-awselasticsearchnode/definition.yml
+++ b/definitions/infra-awselasticsearchnode/definition.yml
@@ -8,3 +8,6 @@ compositeMetrics:
   - golden_metrics.yml
   summaryMetrics:
   - summary_metrics.yml
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true

--- a/definitions/infra-awselb/definition.yml
+++ b/definitions/infra-awselb/definition.yml
@@ -10,3 +10,6 @@ compositeMetrics:
   - golden_metrics.yml
   summaryMetrics:
   - summary_metrics.yml
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true

--- a/definitions/infra-awsfsxwindowsfileserver/definition.yml
+++ b/definitions/infra-awsfsxwindowsfileserver/definition.yml
@@ -6,3 +6,6 @@ goldenTags:
 compositeMetrics:
   goldenMetrics:
   - golden_metrics.yml
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true

--- a/definitions/infra-awsgluejob/definition.yml
+++ b/definitions/infra-awsgluejob/definition.yml
@@ -1,2 +1,5 @@
 domain: INFRA
 type: AWSGLUEJOB
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true

--- a/definitions/infra-awshealthissue/definition.yml
+++ b/definitions/infra-awshealthissue/definition.yml
@@ -1,2 +1,5 @@
 domain: INFRA
 type: AWSHEALTHISSUE
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true

--- a/definitions/infra-awshealthunknown/definition.yml
+++ b/definitions/infra-awshealthunknown/definition.yml
@@ -1,2 +1,5 @@
 domain: INFRA
 type: AWSHEALTHUNKNOWN
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true

--- a/definitions/infra-awsiam/definition.yml
+++ b/definitions/infra-awsiam/definition.yml
@@ -1,2 +1,5 @@
 domain: INFRA
 type: AWSIAM
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true

--- a/definitions/infra-awsiamgroup/definition.yml
+++ b/definitions/infra-awsiamgroup/definition.yml
@@ -1,2 +1,5 @@
 domain: INFRA
 type: AWSIAMGROUP
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true

--- a/definitions/infra-awsiamopenidprovider/definition.yml
+++ b/definitions/infra-awsiamopenidprovider/definition.yml
@@ -1,2 +1,5 @@
 domain: INFRA
 type: AWSIAMOPENIDPROVIDER
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true

--- a/definitions/infra-awsiampolicy/definition.yml
+++ b/definitions/infra-awsiampolicy/definition.yml
@@ -1,2 +1,5 @@
 domain: INFRA
 type: AWSIAMPOLICY
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true

--- a/definitions/infra-awsiamrole/definition.yml
+++ b/definitions/infra-awsiamrole/definition.yml
@@ -1,2 +1,5 @@
 domain: INFRA
 type: AWSIAMROLE
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true

--- a/definitions/infra-awsiamsamlprovider/definition.yml
+++ b/definitions/infra-awsiamsamlprovider/definition.yml
@@ -1,2 +1,5 @@
 domain: INFRA
 type: AWSIAMSAMLPROVIDER
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true

--- a/definitions/infra-awsiamservercertificate/definition.yml
+++ b/definitions/infra-awsiamservercertificate/definition.yml
@@ -1,2 +1,5 @@
 domain: INFRA
 type: AWSIAMSERVERCERTIFICATE
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true

--- a/definitions/infra-awsiamuser/definition.yml
+++ b/definitions/infra-awsiamuser/definition.yml
@@ -1,2 +1,5 @@
 domain: INFRA
 type: AWSIAMUSER
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true

--- a/definitions/infra-awsiamvirtualmfadevice/definition.yml
+++ b/definitions/infra-awsiamvirtualmfadevice/definition.yml
@@ -1,2 +1,5 @@
 domain: INFRA
 type: AWSIAMVIRTUALMFADEVICE
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true

--- a/definitions/infra-awsiotbroker/definition.yml
+++ b/definitions/infra-awsiotbroker/definition.yml
@@ -3,3 +3,6 @@ type: AWSIOTBROKER
 compositeMetrics:
   summaryMetrics:
   - summary_metrics.yml
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true

--- a/definitions/infra-awsiotrule/definition.yml
+++ b/definitions/infra-awsiotrule/definition.yml
@@ -3,3 +3,6 @@ type: AWSIOTRULE
 compositeMetrics:
   summaryMetrics:
   - summary_metrics.yml
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true

--- a/definitions/infra-awsiotruleaction/definition.yml
+++ b/definitions/infra-awsiotruleaction/definition.yml
@@ -3,3 +3,6 @@ type: AWSIOTRULEACTION
 compositeMetrics:
   summaryMetrics:
   - summary_metrics.yml
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true

--- a/definitions/infra-awskinesisanalyticsapplication/definition.yml
+++ b/definitions/infra-awskinesisanalyticsapplication/definition.yml
@@ -9,3 +9,6 @@ compositeMetrics:
   - golden_metrics.yml
   summaryMetrics:
   - summary_metrics.yml
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true

--- a/definitions/infra-awskinesisanalyticstask/definition.yml
+++ b/definitions/infra-awskinesisanalyticstask/definition.yml
@@ -9,3 +9,6 @@ compositeMetrics:
   - golden_metrics.yml
   summaryMetrics:
   - summary_metrics.yml
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true

--- a/definitions/infra-awskinesisdeliverystream/definition.yml
+++ b/definitions/infra-awskinesisdeliverystream/definition.yml
@@ -10,3 +10,6 @@ compositeMetrics:
   - golden_metrics.yml
   summaryMetrics:
   - summary_metrics.yml
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true

--- a/definitions/infra-awskinesisstream/definition.yml
+++ b/definitions/infra-awskinesisstream/definition.yml
@@ -9,3 +9,6 @@ compositeMetrics:
   - golden_metrics.yml
   summaryMetrics:
   - summary_metrics.yml
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true

--- a/definitions/infra-awskinesisstreamshard/definition.yml
+++ b/definitions/infra-awskinesisstreamshard/definition.yml
@@ -10,3 +10,6 @@ compositeMetrics:
   - golden_metrics.yml
   summaryMetrics:
   - summary_metrics.yml
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true

--- a/definitions/infra-awslambdaagenttransaction/definition.yml
+++ b/definitions/infra-awslambdaagenttransaction/definition.yml
@@ -1,2 +1,5 @@
 domain: INFRA
 type: AWSLAMBDAAGENTTRANSACTION
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true

--- a/definitions/infra-awslambdaagenttransactionerror/definition.yml
+++ b/definitions/infra-awslambdaagenttransactionerror/definition.yml
@@ -1,2 +1,5 @@
 domain: INFRA
 type: AWSLAMBDAAGENTTRANSACTIONERROR
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true

--- a/definitions/infra-awslambdaedgefunction/definition.yml
+++ b/definitions/infra-awslambdaedgefunction/definition.yml
@@ -1,2 +1,5 @@
 domain: INFRA
 type: AWSLAMBDAEDGEFUNCTION
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true

--- a/definitions/infra-awslambdafunction/definition.yml
+++ b/definitions/infra-awslambdafunction/definition.yml
@@ -1,17 +1,20 @@
 domain: INFRA
 type: AWSLAMBDAFUNCTION
 goldenTags:
-  - aws.awsRegion
-  - aws.accountId
-  - aws.memorySize
-  - aws.runtime
-  - aws.timeout
-  - aws.handler
-  - account
-  - label.Team
-  - label.team
-  - label.env
-  - label.environment
+- aws.awsRegion
+- aws.accountId
+- aws.memorySize
+- aws.runtime
+- aws.timeout
+- aws.handler
+- account
+- label.Team
+- label.team
+- label.env
+- label.environment
 compositeMetrics:
   goldenMetrics:
   - golden_metrics.yml
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true

--- a/definitions/infra-awslambdafunctionalias/definition.yml
+++ b/definitions/infra-awslambdafunctionalias/definition.yml
@@ -1,17 +1,20 @@
 domain: INFRA
 type: AWSLAMBDAFUNCTIONALIAS
 goldenTags:
-  - aws.region
-  - aws.accountId
-  - aws.aliasName
-  - aws.functionName
-  - aws.functionVersion
-  - aws.resource
-  - account
-  - label.Team
-  - label.team
-  - label.env
-  - label.environment
+- aws.region
+- aws.accountId
+- aws.aliasName
+- aws.functionName
+- aws.functionVersion
+- aws.resource
+- account
+- label.Team
+- label.team
+- label.env
+- label.environment
 compositeMetrics:
   goldenMetrics:
   - golden_metrics.yml
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true

--- a/definitions/infra-awslambdaoperation/definition.yml
+++ b/definitions/infra-awslambdaoperation/definition.yml
@@ -1,2 +1,5 @@
 domain: INFRA
 type: AWSLAMBDAOPERATION
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true

--- a/definitions/infra-awslambdaregion/definition.yml
+++ b/definitions/infra-awslambdaregion/definition.yml
@@ -1,14 +1,17 @@
 domain: INFRA
 type: AWSLAMBDAREGION
 goldenTags:
-  - aws.awsRegion
-  - aws.accountId
-  - aws.concurrentExecutions
-  - account
-  - label.Team
-  - label.team
-  - label.env
-  - label.environment
+- aws.awsRegion
+- aws.accountId
+- aws.concurrentExecutions
+- account
+- label.Team
+- label.team
+- label.env
+- label.environment
 compositeMetrics:
   goldenMetrics:
   - golden_metrics.yml
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true

--- a/definitions/infra-awslambdaspan/definition.yml
+++ b/definitions/infra-awslambdaspan/definition.yml
@@ -1,2 +1,5 @@
 domain: INFRA
 type: AWSLAMBDASPAN
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true

--- a/definitions/infra-awslambdatrace/definition.yml
+++ b/definitions/infra-awslambdatrace/definition.yml
@@ -1,2 +1,5 @@
 domain: INFRA
 type: AWSLAMBDATRACE
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true

--- a/definitions/infra-awsmediaconvertoperation/definition.yml
+++ b/definitions/infra-awsmediaconvertoperation/definition.yml
@@ -6,3 +6,6 @@ goldenTags:
 compositeMetrics:
   goldenMetrics:
   - golden_metrics.yml
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true

--- a/definitions/infra-awsmediaconvertqueue/definition.yml
+++ b/definitions/infra-awsmediaconvertqueue/definition.yml
@@ -6,3 +6,6 @@ goldenTags:
 compositeMetrics:
   goldenMetrics:
   - golden_metrics.yml
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true

--- a/definitions/infra-awsmediapackagevodpackagingconfiguration/definition.yml
+++ b/definitions/infra-awsmediapackagevodpackagingconfiguration/definition.yml
@@ -6,3 +6,6 @@ goldenTags:
 compositeMetrics:
   goldenMetrics:
   - golden_metrics.yml
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true

--- a/definitions/infra-awsmqbroker/definition.yml
+++ b/definitions/infra-awsmqbroker/definition.yml
@@ -1,2 +1,5 @@
 domain: INFRA
 type: AWSMQBROKER
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true

--- a/definitions/infra-awsmqqueue/definition.yml
+++ b/definitions/infra-awsmqqueue/definition.yml
@@ -1,2 +1,5 @@
 domain: INFRA
 type: AWSMQQUEUE
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true

--- a/definitions/infra-awsmqtopic/definition.yml
+++ b/definitions/infra-awsmqtopic/definition.yml
@@ -1,2 +1,5 @@
 domain: INFRA
 type: AWSMQTOPIC
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true

--- a/definitions/infra-awsmskbroker/definition.yml
+++ b/definitions/infra-awsmskbroker/definition.yml
@@ -6,3 +6,6 @@ goldenTags:
 compositeMetrics:
   goldenMetrics:
   - golden_metrics.yml
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true

--- a/definitions/infra-awsmskcluster/definition.yml
+++ b/definitions/infra-awsmskcluster/definition.yml
@@ -6,3 +6,6 @@ goldenTags:
 compositeMetrics:
   goldenMetrics:
   - golden_metrics.yml
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true

--- a/definitions/infra-awsmsktopic/definition.yml
+++ b/definitions/infra-awsmsktopic/definition.yml
@@ -1,2 +1,5 @@
 domain: INFRA
 type: AWSMSKTOPIC
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true

--- a/definitions/infra-awsneptunecluster/definition.yml
+++ b/definitions/infra-awsneptunecluster/definition.yml
@@ -1,2 +1,5 @@
 domain: INFRA
 type: AWSNEPTUNECLUSTER
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true

--- a/definitions/infra-awsneptuneclusterbyrole/definition.yml
+++ b/definitions/infra-awsneptuneclusterbyrole/definition.yml
@@ -1,2 +1,5 @@
 domain: INFRA
 type: AWSNEPTUNECLUSTERBYROLE
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true

--- a/definitions/infra-awsneptunedatabaseclass/definition.yml
+++ b/definitions/infra-awsneptunedatabaseclass/definition.yml
@@ -1,2 +1,5 @@
 domain: INFRA
 type: AWSNEPTUNEDATABASECLASS
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true

--- a/definitions/infra-awsneptuneinstance/definition.yml
+++ b/definitions/infra-awsneptuneinstance/definition.yml
@@ -1,2 +1,5 @@
 domain: INFRA
 type: AWSNEPTUNEINSTANCE
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true

--- a/definitions/infra-awsnlb/definition.yml
+++ b/definitions/infra-awsnlb/definition.yml
@@ -1,19 +1,22 @@
 domain: INFRA
 type: AWSNLB
 goldenTags:
-  - aws.awsRegion
-  - aws.state
-  - aws.type
-  - aws.ipAdressType
-  - aws.dnsName
-  - aws.accountId
-  - account 
-  - label.Team
-  - label.team
-  - label.env
-  - label.environment
+- aws.awsRegion
+- aws.state
+- aws.type
+- aws.ipAdressType
+- aws.dnsName
+- aws.accountId
+- account
+- label.Team
+- label.team
+- label.env
+- label.environment
 compositeMetrics:
   goldenMetrics:
   - golden_metrics.yml
   summaryMetrics:
   - summary_metrics.yml
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true

--- a/definitions/infra-awsnlblistener/definition.yml
+++ b/definitions/infra-awsnlblistener/definition.yml
@@ -1,2 +1,5 @@
 domain: INFRA
 type: AWSNLBLISTENER
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true

--- a/definitions/infra-awsnlblistenerrule/definition.yml
+++ b/definitions/infra-awsnlblistenerrule/definition.yml
@@ -1,2 +1,5 @@
 domain: INFRA
 type: AWSNLBLISTENERRULE
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true

--- a/definitions/infra-awsnlbtargetgroup/definition.yml
+++ b/definitions/infra-awsnlbtargetgroup/definition.yml
@@ -1,19 +1,22 @@
 domain: INFRA
 type: AWSNLBTARGETGROUP
 goldenTags:
-  - aws.awsRegion
-  - aws.port
-  - aws.protocol
-  - aws.matcher
-  - aws.targetGroupName
-  - aws.accountId
-  - account 
-  - label.Team
-  - label.team
-  - label.env
-  - label.environment
+- aws.awsRegion
+- aws.port
+- aws.protocol
+- aws.matcher
+- aws.targetGroupName
+- aws.accountId
+- account
+- label.Team
+- label.team
+- label.env
+- label.environment
 compositeMetrics:
   goldenMetrics:
   - golden_metrics.yml
   summaryMetrics:
   - summary_metrics.yml
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true

--- a/definitions/infra-awsqldbledger/definition.yml
+++ b/definitions/infra-awsqldbledger/definition.yml
@@ -1,2 +1,5 @@
 domain: INFRA
 type: AWSQLDBLEDGER
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true

--- a/definitions/infra-awsrdsdbcluster/definition.yml
+++ b/definitions/infra-awsrdsdbcluster/definition.yml
@@ -8,3 +8,6 @@ compositeMetrics:
   - golden_metrics.yml
   summaryMetrics:
   - summary_metrics.yml
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true

--- a/definitions/infra-awsrdsdbinstance/definition.yml
+++ b/definitions/infra-awsrdsdbinstance/definition.yml
@@ -8,3 +8,6 @@ compositeMetrics:
   - golden_metrics.yml
   summaryMetrics:
   - summary_metrics.yml
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true

--- a/definitions/infra-awsredshiftcluster/definition.yml
+++ b/definitions/infra-awsredshiftcluster/definition.yml
@@ -1,18 +1,21 @@
 domain: INFRA
 type: AWSREDSHIFTCLUSTER
 goldenTags:
-  - aws.awsRegion
-  - aws.clusterId
-  - aws.accountId
-  - aws.dbName
-  - aws.nodeType
-  - account
-  - label.Team
-  - label.team
-  - label.env
-  - label.environment
+- aws.awsRegion
+- aws.clusterId
+- aws.accountId
+- aws.dbName
+- aws.nodeType
+- account
+- label.Team
+- label.team
+- label.env
+- label.environment
 compositeMetrics:
   goldenMetrics:
   - golden_metrics.yml
   summaryMetrics:
   - summary_metrics.yml
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true

--- a/definitions/infra-awsredshiftnode/definition.yml
+++ b/definitions/infra-awsredshiftnode/definition.yml
@@ -1,17 +1,20 @@
 domain: INFRA
 type: AWSREDSHIFTNODE
 goldenTags:
-  - aws.awsRegion
-  - aws.clusterId
-  - aws.accountId
-  - aws.nodeId
-  - account
-  - label.Team
-  - label.team
-  - label.env
-  - label.environment
+- aws.awsRegion
+- aws.clusterId
+- aws.accountId
+- aws.nodeId
+- account
+- label.Team
+- label.team
+- label.env
+- label.environment
 compositeMetrics:
   goldenMetrics:
   - golden_metrics.yml
   summaryMetrics:
   - summary_metrics.yml
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true

--- a/definitions/infra-awsroute53healthcheck/definition.yml
+++ b/definitions/infra-awsroute53healthcheck/definition.yml
@@ -3,3 +3,6 @@ type: AWSROUTE53HEALTHCHECK
 compositeMetrics:
   summaryMetrics:
   - summary_metrics.yml
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true

--- a/definitions/infra-awsroute53resolverendpoint/definition.yml
+++ b/definitions/infra-awsroute53resolverendpoint/definition.yml
@@ -1,2 +1,5 @@
 domain: INFRA
 type: AWSROUTE53RESOLVERENDPOINT
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true

--- a/definitions/infra-awss3bucket/definition.yml
+++ b/definitions/infra-awss3bucket/definition.yml
@@ -9,3 +9,6 @@ compositeMetrics:
   - golden_metrics.yml
   summaryMetrics:
   - summary_metrics.yml
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true

--- a/definitions/infra-awss3bucketrequests/definition.yml
+++ b/definitions/infra-awss3bucketrequests/definition.yml
@@ -1,2 +1,5 @@
 domain: INFRA
 type: AWSS3BUCKETREQUESTS
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true

--- a/definitions/infra-awssesregion/definition.yml
+++ b/definitions/infra-awssesregion/definition.yml
@@ -3,3 +3,6 @@ type: AWSSESREGION
 compositeMetrics:
   summaryMetrics:
   - summary_metrics.yml
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true

--- a/definitions/infra-awssnssubscription/definition.yml
+++ b/definitions/infra-awssnssubscription/definition.yml
@@ -1,2 +1,5 @@
 domain: INFRA
 type: AWSSNSSUBSCRIPTION
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true

--- a/definitions/infra-awssnstopic/definition.yml
+++ b/definitions/infra-awssnstopic/definition.yml
@@ -9,3 +9,6 @@ compositeMetrics:
   - golden_metrics.yml
   summaryMetrics:
   - summary_metrics.yml
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true

--- a/definitions/infra-awssqsqueue/definition.yml
+++ b/definitions/infra-awssqsqueue/definition.yml
@@ -9,3 +9,6 @@ compositeMetrics:
   - golden_metrics.yml
   summaryMetrics:
   - summary_metrics.yml
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true

--- a/definitions/infra-awsstatesactivity/definition.yml
+++ b/definitions/infra-awsstatesactivity/definition.yml
@@ -1,2 +1,5 @@
 domain: INFRA
 type: AWSSTATESACTIVITY
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true

--- a/definitions/infra-awsstatesapiusage/definition.yml
+++ b/definitions/infra-awsstatesapiusage/definition.yml
@@ -1,2 +1,5 @@
 domain: INFRA
 type: AWSSTATESAPIUSAGE
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true

--- a/definitions/infra-awsstateslambdafunction/definition.yml
+++ b/definitions/infra-awsstateslambdafunction/definition.yml
@@ -1,2 +1,5 @@
 domain: INFRA
 type: AWSSTATESLAMBDAFUNCTION
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true

--- a/definitions/infra-awsstatesservice/definition.yml
+++ b/definitions/infra-awsstatesservice/definition.yml
@@ -1,2 +1,5 @@
 domain: INFRA
 type: AWSSTATESSERVICE
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true

--- a/definitions/infra-awsstatesserviceintegration/definition.yml
+++ b/definitions/infra-awsstatesserviceintegration/definition.yml
@@ -1,2 +1,5 @@
 domain: INFRA
 type: AWSSTATESSERVICEINTEGRATION
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true

--- a/definitions/infra-awsstatesstatemachine/definition.yml
+++ b/definitions/infra-awsstatesstatemachine/definition.yml
@@ -6,3 +6,6 @@ goldenTags:
 compositeMetrics:
   goldenMetrics:
   - golden_metrics.yml
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true

--- a/definitions/infra-awstransitgatewaytransitgateway/definition.yml
+++ b/definitions/infra-awstransitgatewaytransitgateway/definition.yml
@@ -1,2 +1,5 @@
 domain: INFRA
 type: AWSTRANSITGATEWAYTRANSITGATEWAY
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true

--- a/definitions/infra-awswafv2rulegroup/definition.yml
+++ b/definitions/infra-awswafv2rulegroup/definition.yml
@@ -1,2 +1,5 @@
 domain: INFRA
 type: AWSWAFV2RULEGROUP
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true

--- a/definitions/infra-awswafv2webacl/definition.yml
+++ b/definitions/infra-awswafv2webacl/definition.yml
@@ -1,2 +1,5 @@
 domain: INFRA
 type: AWSWAFV2WEBACL
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true

--- a/definitions/infra-awswafwebacl/definition.yml
+++ b/definitions/infra-awswafwebacl/definition.yml
@@ -1,2 +1,5 @@
 domain: INFRA
 type: AWSWAFWEBACL
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true

--- a/definitions/infra-azureapimanagementservice/definition.yml
+++ b/definitions/infra-azureapimanagementservice/definition.yml
@@ -10,3 +10,6 @@ compositeMetrics:
   - golden_metrics.yml
   summaryMetrics:
   - summary_metrics.yml
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true

--- a/definitions/infra-azureapplicationgateway/definition.yml
+++ b/definitions/infra-azureapplicationgateway/definition.yml
@@ -6,3 +6,6 @@ goldenTags:
 compositeMetrics:
   goldenMetrics:
   - golden_metrics.yml
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true

--- a/definitions/infra-azureappservicehostname/definition.yml
+++ b/definitions/infra-azureappservicehostname/definition.yml
@@ -1,2 +1,5 @@
 domain: INFRA
 type: AZUREAPPSERVICEHOSTNAME
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true

--- a/definitions/infra-azureappserviceplan/definition.yml
+++ b/definitions/infra-azureappserviceplan/definition.yml
@@ -3,3 +3,6 @@ type: AZUREAPPSERVICEPLAN
 compositeMetrics:
   summaryMetrics:
   - summary_metrics.yml
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true

--- a/definitions/infra-azureappservicewebapp/definition.yml
+++ b/definitions/infra-azureappservicewebapp/definition.yml
@@ -12,3 +12,6 @@ compositeMetrics:
   - golden_metrics.yml
   summaryMetrics:
   - summary_metrics.yml
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true

--- a/definitions/infra-azurecontainersinstancegroup/definition.yml
+++ b/definitions/infra-azurecontainersinstancegroup/definition.yml
@@ -6,3 +6,6 @@ goldenTags:
 compositeMetrics:
   goldenMetrics:
   - golden_metrics.yml
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true

--- a/definitions/infra-azurecontainersmanagedcluster/definition.yml
+++ b/definitions/infra-azurecontainersmanagedcluster/definition.yml
@@ -6,3 +6,6 @@ goldenTags:
 compositeMetrics:
   goldenMetrics:
   - golden_metrics.yml
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true

--- a/definitions/infra-azurecontainersregistry/definition.yml
+++ b/definitions/infra-azurecontainersregistry/definition.yml
@@ -6,3 +6,6 @@ goldenTags:
 compositeMetrics:
   goldenMetrics:
   - golden_metrics.yml
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true

--- a/definitions/infra-azurecosmosdbaccount/definition.yml
+++ b/definitions/infra-azurecosmosdbaccount/definition.yml
@@ -10,3 +10,6 @@ compositeMetrics:
   - golden_metrics.yml
   summaryMetrics:
   - summary_metrics.yml
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true

--- a/definitions/infra-azurecosmosdbcollection/definition.yml
+++ b/definitions/infra-azurecosmosdbcollection/definition.yml
@@ -10,3 +10,6 @@ compositeMetrics:
   - golden_metrics.yml
   summaryMetrics:
   - summary_metrics.yml
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true

--- a/definitions/infra-azurecosmosdbdatabase/definition.yml
+++ b/definitions/infra-azurecosmosdbdatabase/definition.yml
@@ -10,3 +10,6 @@ compositeMetrics:
   - golden_metrics.yml
   summaryMetrics:
   - summary_metrics.yml
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true

--- a/definitions/infra-azuredatafactorydatafactory/definition.yml
+++ b/definitions/infra-azuredatafactorydatafactory/definition.yml
@@ -6,3 +6,6 @@ goldenTags:
 compositeMetrics:
   goldenMetrics:
   - golden_metrics.yml
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true

--- a/definitions/infra-azuredatafactoryfactory/definition.yml
+++ b/definitions/infra-azuredatafactoryfactory/definition.yml
@@ -1,2 +1,5 @@
 domain: INFRA
 type: AZUREDATAFACTORYFACTORY
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true

--- a/definitions/infra-azureeventhubcluster/definition.yml
+++ b/definitions/infra-azureeventhubcluster/definition.yml
@@ -6,3 +6,6 @@ goldenTags:
 compositeMetrics:
   goldenMetrics:
   - golden_metrics.yml
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true

--- a/definitions/infra-azureeventhubnamespace/definition.yml
+++ b/definitions/infra-azureeventhubnamespace/definition.yml
@@ -6,3 +6,6 @@ goldenTags:
 compositeMetrics:
   goldenMetrics:
   - golden_metrics.yml
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true

--- a/definitions/infra-azureexpressroutecircuit/definition.yml
+++ b/definitions/infra-azureexpressroutecircuit/definition.yml
@@ -1,2 +1,5 @@
 domain: INFRA
 type: AZUREEXPRESSROUTECIRCUIT
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true

--- a/definitions/infra-azureexpressrouteconnection/definition.yml
+++ b/definitions/infra-azureexpressrouteconnection/definition.yml
@@ -1,2 +1,5 @@
 domain: INFRA
 type: AZUREEXPRESSROUTECONNECTION
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true

--- a/definitions/infra-azureexpressroutegateway/definition.yml
+++ b/definitions/infra-azureexpressroutegateway/definition.yml
@@ -1,2 +1,5 @@
 domain: INFRA
 type: AZUREEXPRESSROUTEGATEWAY
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true

--- a/definitions/infra-azureexpressroutepeering/definition.yml
+++ b/definitions/infra-azureexpressroutepeering/definition.yml
@@ -1,2 +1,5 @@
 domain: INFRA
 type: AZUREEXPRESSROUTEPEERING
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true

--- a/definitions/infra-azureexpressrouteport/definition.yml
+++ b/definitions/infra-azureexpressrouteport/definition.yml
@@ -1,2 +1,5 @@
 domain: INFRA
 type: AZUREEXPRESSROUTEPORT
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true

--- a/definitions/infra-azurefirewall/definition.yml
+++ b/definitions/infra-azurefirewall/definition.yml
@@ -1,9 +1,11 @@
 domain: INFRA
 type: AZUREFIREWALL
-
 compositeMetrics:
-   goldenMetrics:
-      - golden_metrics.yml
+  goldenMetrics:
+  - golden_metrics.yml
 goldenTags:
-   - azure.regionName
-   - azure.subscriptionId
+- azure.regionName
+- azure.subscriptionId
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true

--- a/definitions/infra-azurefrontdoorfrontdoor/definition.yml
+++ b/definitions/infra-azurefrontdoorfrontdoor/definition.yml
@@ -6,3 +6,6 @@ goldenTags:
 compositeMetrics:
   goldenMetrics:
   - golden_metrics.yml
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true

--- a/definitions/infra-azurefunctionsapp/definition.yml
+++ b/definitions/infra-azurefunctionsapp/definition.yml
@@ -11,3 +11,6 @@ compositeMetrics:
   - golden_metrics.yml
   summaryMetrics:
   - summary_metrics.yml
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true

--- a/definitions/infra-azurekeyvaultvault/definition.yml
+++ b/definitions/infra-azurekeyvaultvault/definition.yml
@@ -6,3 +6,6 @@ goldenTags:
 compositeMetrics:
   goldenMetrics:
   - golden_metrics.yml
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true

--- a/definitions/infra-azureloadbalancer/definition.yml
+++ b/definitions/infra-azureloadbalancer/definition.yml
@@ -10,3 +10,6 @@ compositeMetrics:
   - golden_metrics.yml
   summaryMetrics:
   - summary_metrics.yml
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true

--- a/definitions/infra-azureloadbalancerbackend/definition.yml
+++ b/definitions/infra-azureloadbalancerbackend/definition.yml
@@ -1,2 +1,5 @@
 domain: INFRA
 type: AZURELOADBALANCERBACKEND
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true

--- a/definitions/infra-azureloadbalancerfrontendip/definition.yml
+++ b/definitions/infra-azureloadbalancerfrontendip/definition.yml
@@ -1,2 +1,5 @@
 domain: INFRA
 type: AZURELOADBALANCERFRONTENDIP
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true

--- a/definitions/infra-azureloadbalancerinboundnatpool/definition.yml
+++ b/definitions/infra-azureloadbalancerinboundnatpool/definition.yml
@@ -1,2 +1,5 @@
 domain: INFRA
 type: AZURELOADBALANCERINBOUNDNATPOOL
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true

--- a/definitions/infra-azureloadbalancerinboundnatrule/definition.yml
+++ b/definitions/infra-azureloadbalancerinboundnatrule/definition.yml
@@ -1,2 +1,5 @@
 domain: INFRA
 type: AZURELOADBALANCERINBOUNDNATRULE
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true

--- a/definitions/infra-azureloadbalancerprobe/definition.yml
+++ b/definitions/infra-azureloadbalancerprobe/definition.yml
@@ -1,2 +1,5 @@
 domain: INFRA
 type: AZURELOADBALANCERPROBE
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true

--- a/definitions/infra-azureloadbalancerrule/definition.yml
+++ b/definitions/infra-azureloadbalancerrule/definition.yml
@@ -1,2 +1,5 @@
 domain: INFRA
 type: AZURELOADBALANCERRULE
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true

--- a/definitions/infra-azurelogicappsintegrationserviceenvironment/definition.yml
+++ b/definitions/infra-azurelogicappsintegrationserviceenvironment/definition.yml
@@ -6,3 +6,6 @@ goldenTags:
 compositeMetrics:
   goldenMetrics:
   - golden_metrics.yml
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true

--- a/definitions/infra-azurelogicappsworkflow/definition.yml
+++ b/definitions/infra-azurelogicappsworkflow/definition.yml
@@ -6,3 +6,6 @@ goldenTags:
 compositeMetrics:
   goldenMetrics:
   - golden_metrics.yml
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true

--- a/definitions/infra-azuremachinelearningworkspace/definition.yml
+++ b/definitions/infra-azuremachinelearningworkspace/definition.yml
@@ -1,2 +1,5 @@
 domain: INFRA
 type: AZUREMACHINELEARNINGWORKSPACE
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true

--- a/definitions/infra-azuremariadbserver/definition.yml
+++ b/definitions/infra-azuremariadbserver/definition.yml
@@ -12,3 +12,6 @@ compositeMetrics:
   - golden_metrics.yml
   summaryMetrics:
   - summary_metrics.yml
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true

--- a/definitions/infra-azuremysqlserver/definition.yml
+++ b/definitions/infra-azuremysqlserver/definition.yml
@@ -12,3 +12,6 @@ compositeMetrics:
   - golden_metrics.yml
   summaryMetrics:
   - summary_metrics.yml
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true

--- a/definitions/infra-azurepostgresqlserver/definition.yml
+++ b/definitions/infra-azurepostgresqlserver/definition.yml
@@ -12,3 +12,6 @@ compositeMetrics:
   - golden_metrics.yml
   summaryMetrics:
   - summary_metrics.yml
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true

--- a/definitions/infra-azurepowerbidedicatedcapacity/definition.yml
+++ b/definitions/infra-azurepowerbidedicatedcapacity/definition.yml
@@ -6,3 +6,6 @@ goldenTags:
 compositeMetrics:
   goldenMetrics:
   - golden_metrics.yml
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true

--- a/definitions/infra-azurerediscache/definition.yml
+++ b/definitions/infra-azurerediscache/definition.yml
@@ -3,3 +3,6 @@ type: AZUREREDISCACHE
 compositeMetrics:
   summaryMetrics:
   - summary_metrics.yml
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true

--- a/definitions/infra-azurerediscacheshard/definition.yml
+++ b/definitions/infra-azurerediscacheshard/definition.yml
@@ -3,3 +3,6 @@ type: AZUREREDISCACHESHARD
 compositeMetrics:
   summaryMetrics:
   - summary_metrics.yml
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true

--- a/definitions/infra-azureservicebusnamespace/definition.yml
+++ b/definitions/infra-azureservicebusnamespace/definition.yml
@@ -11,3 +11,6 @@ compositeMetrics:
   - golden_metrics.yml
   summaryMetrics:
   - summary_metrics.yml
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true

--- a/definitions/infra-azureservicebusqueue/definition.yml
+++ b/definitions/infra-azureservicebusqueue/definition.yml
@@ -1,2 +1,5 @@
 domain: INFRA
 type: AZURESERVICEBUSQUEUE
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true

--- a/definitions/infra-azureservicebussubscription/definition.yml
+++ b/definitions/infra-azureservicebussubscription/definition.yml
@@ -1,2 +1,5 @@
 domain: INFRA
 type: AZURESERVICEBUSSUBSCRIPTION
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true

--- a/definitions/infra-azureservicebustopic/definition.yml
+++ b/definitions/infra-azureservicebustopic/definition.yml
@@ -1,2 +1,5 @@
 domain: INFRA
 type: AZURESERVICEBUSTOPIC
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true

--- a/definitions/infra-azuresqldatabase/definition.yml
+++ b/definitions/infra-azuresqldatabase/definition.yml
@@ -14,3 +14,6 @@ compositeMetrics:
   - golden_metrics.yml
   summaryMetrics:
   - summary_metrics.yml
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true

--- a/definitions/infra-azuresqlelasticpool/definition.yml
+++ b/definitions/infra-azuresqlelasticpool/definition.yml
@@ -3,3 +3,6 @@ type: AZURESQLELASTICPOOL
 compositeMetrics:
   summaryMetrics:
   - summary_metrics.yml
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true

--- a/definitions/infra-azuresqlfirewall/definition.yml
+++ b/definitions/infra-azuresqlfirewall/definition.yml
@@ -1,2 +1,5 @@
 domain: INFRA
 type: AZURESQLFIREWALL
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true

--- a/definitions/infra-azuresqlmanagedinstance/definition.yml
+++ b/definitions/infra-azuresqlmanagedinstance/definition.yml
@@ -6,3 +6,6 @@ goldenTags:
 compositeMetrics:
   goldenMetrics:
   - golden_metrics.yml
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true

--- a/definitions/infra-azuresqlreplicationlink/definition.yml
+++ b/definitions/infra-azuresqlreplicationlink/definition.yml
@@ -1,2 +1,5 @@
 domain: INFRA
 type: AZURESQLREPLICATIONLINK
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true

--- a/definitions/infra-azuresqlrestorepoint/definition.yml
+++ b/definitions/infra-azuresqlrestorepoint/definition.yml
@@ -1,2 +1,5 @@
 domain: INFRA
 type: AZURESQLRESTOREPOINT
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true

--- a/definitions/infra-azuresqlserver/definition.yml
+++ b/definitions/infra-azuresqlserver/definition.yml
@@ -2,4 +2,7 @@ domain: INFRA
 type: AZURESQLSERVER
 compositeMetrics:
   summaryMetrics:
-    - summary_metrics.yml
+  - summary_metrics.yml
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true

--- a/definitions/infra-azurestorageaccount/definition.yml
+++ b/definitions/infra-azurestorageaccount/definition.yml
@@ -12,3 +12,6 @@ compositeMetrics:
   - golden_metrics.yml
   summaryMetrics:
   - summary_metrics.yml
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true

--- a/definitions/infra-azurevirtualmachinescaleset/definition.yml
+++ b/definitions/infra-azurevirtualmachinescaleset/definition.yml
@@ -10,3 +10,6 @@ compositeMetrics:
   - golden_metrics.yml
   summaryMetrics:
   - summary_metrics.yml
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true

--- a/definitions/infra-azurevirtualnetworks/definition.yml
+++ b/definitions/infra-azurevirtualnetworks/definition.yml
@@ -1,2 +1,5 @@
 domain: INFRA
 type: AZUREVIRTUALNETWORKS
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true

--- a/definitions/infra-azurevirtualnetworksipconfiguration/definition.yml
+++ b/definitions/infra-azurevirtualnetworksipconfiguration/definition.yml
@@ -1,2 +1,5 @@
 domain: INFRA
 type: AZUREVIRTUALNETWORKSIPCONFIGURATION
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true

--- a/definitions/infra-azurevirtualnetworksnetworkinterface/definition.yml
+++ b/definitions/infra-azurevirtualnetworksnetworkinterface/definition.yml
@@ -1,2 +1,5 @@
 domain: INFRA
 type: AZUREVIRTUALNETWORKSNETWORKINTERFACE
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true

--- a/definitions/infra-azurevirtualnetworkspeering/definition.yml
+++ b/definitions/infra-azurevirtualnetworkspeering/definition.yml
@@ -1,2 +1,5 @@
 domain: INFRA
 type: AZUREVIRTUALNETWORKSPEERING
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true

--- a/definitions/infra-azurevirtualnetworkspublicipaddress/definition.yml
+++ b/definitions/infra-azurevirtualnetworkspublicipaddress/definition.yml
@@ -1,2 +1,5 @@
 domain: INFRA
 type: AZUREVIRTUALNETWORKSPUBLICIPADDRESS
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true

--- a/definitions/infra-azurevirtualnetworksroute/definition.yml
+++ b/definitions/infra-azurevirtualnetworksroute/definition.yml
@@ -1,2 +1,5 @@
 domain: INFRA
 type: AZUREVIRTUALNETWORKSROUTE
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true

--- a/definitions/infra-azurevirtualnetworksroutetable/definition.yml
+++ b/definitions/infra-azurevirtualnetworksroutetable/definition.yml
@@ -1,2 +1,5 @@
 domain: INFRA
 type: AZUREVIRTUALNETWORKSROUTETABLE
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true

--- a/definitions/infra-azurevirtualnetworkssecuritygroup/definition.yml
+++ b/definitions/infra-azurevirtualnetworkssecuritygroup/definition.yml
@@ -1,2 +1,5 @@
 domain: INFRA
 type: AZUREVIRTUALNETWORKSSECURITYGROUP
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true

--- a/definitions/infra-azurevirtualnetworkssubnet/definition.yml
+++ b/definitions/infra-azurevirtualnetworkssubnet/definition.yml
@@ -1,2 +1,5 @@
 domain: INFRA
 type: AZUREVIRTUALNETWORKSSUBNET
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true

--- a/definitions/infra-azurevpngatewaysvpngateway/definition.yml
+++ b/definitions/infra-azurevpngatewaysvpngateway/definition.yml
@@ -1,2 +1,5 @@
 domain: INFRA
 type: AZUREVPNGATEWAYSVPNGATEWAY
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true

--- a/definitions/infra-cassandranode/definition.yml
+++ b/definitions/infra-cassandranode/definition.yml
@@ -1,13 +1,16 @@
 domain: INFRA
 type: CASSANDRANODE
-goldenTags: 
-  - cassandra.hostname
-  - cassandra.port
-  - cassandra.version
-  - cassandra.clusterDatacenter
-  - cassandra.clusterName
+goldenTags:
+- cassandra.hostname
+- cassandra.port
+- cassandra.version
+- cassandra.clusterDatacenter
+- cassandra.clusterName
 compositeMetrics:
   goldenMetrics:
   - golden_metrics.yml
   summaryMetrics:
   - summary_metrics.yml
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true

--- a/definitions/infra-consulagent/definition.yml
+++ b/definitions/infra-consulagent/definition.yml
@@ -3,3 +3,6 @@ type: CONSULAGENT
 compositeMetrics:
   summaryMetrics:
   - summary_metrics.yml
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true

--- a/definitions/infra-container/definition.yml
+++ b/definitions/infra-container/definition.yml
@@ -1,30 +1,26 @@
 domain: INFRA
 type: CONTAINER
-
-# TODO: missing conditions to match on k8s containers, waiting until
-#       we add support for multiple telemetry sources.
 synthesis:
   identifier: entity.id
   name: docker.name
   encodeIdentifierInGUID: true
-
   conditions:
-    - attribute: docker.containerId
-
+  - attribute: docker.containerId
   tags:
-    container.state:
-    docker.state:
-    docker.containerId:
-    newrelic.integrationName:
-    newrelic.integrationVersion:
-    newrelic.agentVersion:
-
+    container.state: null
+    docker.state: null
+    docker.containerId: null
+    newrelic.integrationName: null
+    newrelic.integrationVersion: null
+    newrelic.agentVersion: null
 goldenTags:
 - environment
 - container.state
-
 compositeMetrics:
   goldenMetrics:
   - golden_metrics.yml
   summaryMetrics:
   - summary_metrics.yml
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true

--- a/definitions/infra-couchbasebucket/definition.yml
+++ b/definitions/infra-couchbasebucket/definition.yml
@@ -3,3 +3,6 @@ type: COUCHBASEBUCKET
 compositeMetrics:
   summaryMetrics:
   - summary_metrics.yml
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true

--- a/definitions/infra-couchbasecluster/definition.yml
+++ b/definitions/infra-couchbasecluster/definition.yml
@@ -3,3 +3,6 @@ type: COUCHBASECLUSTER
 compositeMetrics:
   summaryMetrics:
   - summary_metrics.yml
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true

--- a/definitions/infra-couchbasenode/definition.yml
+++ b/definitions/infra-couchbasenode/definition.yml
@@ -1,2 +1,5 @@
 domain: INFRA
 type: COUCHBASENODE
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true

--- a/definitions/infra-couchbasequeryengine/definition.yml
+++ b/definitions/infra-couchbasequeryengine/definition.yml
@@ -1,2 +1,5 @@
 domain: INFRA
 type: COUCHBASEQUERYENGINE
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true

--- a/definitions/infra-dockercontainer/definition.yml
+++ b/definitions/infra-dockercontainer/definition.yml
@@ -1,2 +1,5 @@
 domain: INFRA
 type: DOCKERCONTAINER
+configuration:
+  entityExpirationTime: DAILY
+  alertable: false

--- a/definitions/infra-elasticsearchnode/definition.yml
+++ b/definitions/infra-elasticsearchnode/definition.yml
@@ -1,11 +1,14 @@
 domain: INFRA
 type: ELASTICSEARCHNODE
 goldenTags:
-  - elasticsearch.clusterName
-  - elasticsearch.nodeHostname
-  - elasticsearch.nodeIpAddress
+- elasticsearch.clusterName
+- elasticsearch.nodeHostname
+- elasticsearch.nodeIpAddress
 compositeMetrics:
   goldenMetrics:
   - golden_metrics.yml
   summaryMetrics:
   - summary_metrics.yml
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true

--- a/definitions/infra-etcd_cluster/definition.yml
+++ b/definitions/infra-etcd_cluster/definition.yml
@@ -7,13 +7,13 @@ synthesis:
   - attribute: metricName
     prefix: etcd_
   tags:
-    'label.topology.kubernetes.io/region':
-    'label.topology.kubernetes.io/zone':
-    'label.eks.amazonaws.com/compute-type':
-    'k8s.cluster.name':
-    'label.kubernetes.io/arch':
-    'label.kubernetes.io/hostname':
-    'label.kubernetes.io/os':
+    label.topology.kubernetes.io/region: null
+    label.topology.kubernetes.io/zone: null
+    label.eks.amazonaws.com/compute-type: null
+    k8s.cluster.name: null
+    label.kubernetes.io/arch: null
+    label.kubernetes.io/hostname: null
+    label.kubernetes.io/os: null
 dashboardTemplates:
 - dashboard.json
 goldenTags:
@@ -23,3 +23,6 @@ compositeMetrics:
   - golden_metrics.yml
   summaryMetrics:
   - summary_metrics.yml
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true

--- a/definitions/infra-f5node/definition.yml
+++ b/definitions/infra-f5node/definition.yml
@@ -1,2 +1,5 @@
 domain: INFRA
 type: F5NODE
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true

--- a/definitions/infra-f5pool/definition.yml
+++ b/definitions/infra-f5pool/definition.yml
@@ -4,3 +4,6 @@ goldenTags: []
 compositeMetrics:
   goldenMetrics:
   - golden_metrics.yml
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true

--- a/definitions/infra-f5poolmember/definition.yml
+++ b/definitions/infra-f5poolmember/definition.yml
@@ -4,3 +4,6 @@ goldenTags: []
 compositeMetrics:
   goldenMetrics:
   - golden_metrics.yml
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true

--- a/definitions/infra-f5system/definition.yml
+++ b/definitions/infra-f5system/definition.yml
@@ -3,3 +3,6 @@ type: F5SYSTEM
 compositeMetrics:
   summaryMetrics:
   - summary_metrics.yml
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true

--- a/definitions/infra-f5virtualserver/definition.yml
+++ b/definitions/infra-f5virtualserver/definition.yml
@@ -4,3 +4,6 @@ goldenTags: []
 compositeMetrics:
   goldenMetrics:
   - golden_metrics.yml
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true

--- a/definitions/infra-gcpappengineservice/definition.yml
+++ b/definitions/infra-gcpappengineservice/definition.yml
@@ -8,3 +8,6 @@ compositeMetrics:
   - summary_metrics.yml
   goldenMetrics:
   - golden_metrics.yml
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true

--- a/definitions/infra-gcpbigquerydataset/definition.yml
+++ b/definitions/infra-gcpbigquerydataset/definition.yml
@@ -8,4 +8,6 @@ compositeMetrics:
   - summary_metrics.yml
   goldenMetrics:
   - golden_metrics.yml
-
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true

--- a/definitions/infra-gcpbigqueryproject/definition.yml
+++ b/definitions/infra-gcpbigqueryproject/definition.yml
@@ -3,3 +3,6 @@ type: GCPBIGQUERYPROJECT
 compositeMetrics:
   summaryMetrics:
   - summary_metrics.yml
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true

--- a/definitions/infra-gcpbigquerytable/definition.yml
+++ b/definitions/infra-gcpbigquerytable/definition.yml
@@ -8,3 +8,6 @@ compositeMetrics:
   - summary_metrics.yml
   goldenMetrics:
   - golden_metrics.yml
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true

--- a/definitions/infra-gcpbigtablecluster/definition.yml
+++ b/definitions/infra-gcpbigtablecluster/definition.yml
@@ -6,3 +6,6 @@ goldenTags:
 compositeMetrics:
   goldenMetrics:
   - golden_metrics.yml
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true

--- a/definitions/infra-gcpbigtabletable/definition.yml
+++ b/definitions/infra-gcpbigtabletable/definition.yml
@@ -6,3 +6,6 @@ goldenTags:
 compositeMetrics:
   goldenMetrics:
   - golden_metrics.yml
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true

--- a/definitions/infra-gcpcloudcomposerenvironment/definition.yml
+++ b/definitions/infra-gcpcloudcomposerenvironment/definition.yml
@@ -6,3 +6,6 @@ goldenTags:
 compositeMetrics:
   goldenMetrics:
   - golden_metrics.yml
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true

--- a/definitions/infra-gcpcloudcomposerworkflow/definition.yml
+++ b/definitions/infra-gcpcloudcomposerworkflow/definition.yml
@@ -6,3 +6,6 @@ goldenTags:
 compositeMetrics:
   goldenMetrics:
   - golden_metrics.yml
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true

--- a/definitions/infra-gcpcloudfunction/definition.yml
+++ b/definitions/infra-gcpcloudfunction/definition.yml
@@ -8,3 +8,6 @@ compositeMetrics:
   - summary_metrics.yml
   goldenMetrics:
   - golden_metrics.yml
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true

--- a/definitions/infra-gcpcloudsql/definition.yml
+++ b/definitions/infra-gcpcloudsql/definition.yml
@@ -8,3 +8,6 @@ compositeMetrics:
   - golden_metrics.yml
   summaryMetrics:
   - summary_metrics.yml
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true

--- a/definitions/infra-gcpcloudtasksqueue/definition.yml
+++ b/definitions/infra-gcpcloudtasksqueue/definition.yml
@@ -1,2 +1,5 @@
 domain: INFRA
 type: GCPCLOUDTASKSQUEUE
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true

--- a/definitions/infra-gcpcomposercloudcomposerenvironment/definition.yml
+++ b/definitions/infra-gcpcomposercloudcomposerenvironment/definition.yml
@@ -1,2 +1,5 @@
 domain: INFRA
 type: GCPCOMPOSERCLOUDCOMPOSERENVIRONMENT
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true

--- a/definitions/infra-gcpcomposercloudcomposerworkflow/definition.yml
+++ b/definitions/infra-gcpcomposercloudcomposerworkflow/definition.yml
@@ -1,2 +1,5 @@
 domain: INFRA
 type: GCPCOMPOSERCLOUDCOMPOSERWORKFLOW
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true

--- a/definitions/infra-gcpcomposerenvironment/definition.yml
+++ b/definitions/infra-gcpcomposerenvironment/definition.yml
@@ -1,2 +1,5 @@
 domain: INFRA
 type: GCPCOMPOSERENVIRONMENT
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true

--- a/definitions/infra-gcpcomposerworkflow/definition.yml
+++ b/definitions/infra-gcpcomposerworkflow/definition.yml
@@ -1,2 +1,5 @@
 domain: INFRA
 type: GCPCOMPOSERWORKFLOW
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true

--- a/definitions/infra-gcpdataflowjob/definition.yml
+++ b/definitions/infra-gcpdataflowjob/definition.yml
@@ -1,2 +1,5 @@
 domain: INFRA
 type: GCPDATAFLOWJOB
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true

--- a/definitions/infra-gcpdataproccluster/definition.yml
+++ b/definitions/infra-gcpdataproccluster/definition.yml
@@ -1,2 +1,5 @@
 domain: INFRA
 type: GCPDATAPROCCLUSTER
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true

--- a/definitions/infra-gcpdatastorerequest/definition.yml
+++ b/definitions/infra-gcpdatastorerequest/definition.yml
@@ -1,2 +1,5 @@
 domain: INFRA
 type: GCPDATASTOREREQUEST
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true

--- a/definitions/infra-gcpfirebasedatabasenamespace/definition.yml
+++ b/definitions/infra-gcpfirebasedatabasenamespace/definition.yml
@@ -1,2 +1,5 @@
 domain: INFRA
 type: GCPFIREBASEDATABASENAMESPACE
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true

--- a/definitions/infra-gcpfirebasehostingdomain/definition.yml
+++ b/definitions/infra-gcpfirebasehostingdomain/definition.yml
@@ -1,2 +1,5 @@
 domain: INFRA
 type: GCPFIREBASEHOSTINGDOMAIN
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true

--- a/definitions/infra-gcpfirebasestoragebucket/definition.yml
+++ b/definitions/infra-gcpfirebasestoragebucket/definition.yml
@@ -1,2 +1,5 @@
 domain: INFRA
 type: GCPFIREBASESTORAGEBUCKET
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true

--- a/definitions/infra-gcpfirestoreinstance/definition.yml
+++ b/definitions/infra-gcpfirestoreinstance/definition.yml
@@ -1,2 +1,5 @@
 domain: INFRA
 type: GCPFIRESTOREINSTANCE
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true

--- a/definitions/infra-gcpfirestorerequest/definition.yml
+++ b/definitions/infra-gcpfirestorerequest/definition.yml
@@ -1,2 +1,5 @@
 domain: INFRA
 type: GCPFIRESTOREREQUEST
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true

--- a/definitions/infra-gcphttploadbalancer/definition.yml
+++ b/definitions/infra-gcphttploadbalancer/definition.yml
@@ -8,3 +8,6 @@ compositeMetrics:
   - golden_metrics.yml
   summaryMetrics:
   - summary_metrics.yml
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true

--- a/definitions/infra-gcpinterconnectattachment/definition.yml
+++ b/definitions/infra-gcpinterconnectattachment/definition.yml
@@ -1,2 +1,5 @@
 domain: INFRA
 type: GCPINTERCONNECTATTACHMENT
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true

--- a/definitions/infra-gcpinterconnectinterconnect/definition.yml
+++ b/definitions/infra-gcpinterconnectinterconnect/definition.yml
@@ -1,2 +1,5 @@
 domain: INFRA
 type: GCPINTERCONNECTINTERCONNECT
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true

--- a/definitions/infra-gcpinternalloadbalancer/definition.yml
+++ b/definitions/infra-gcpinternalloadbalancer/definition.yml
@@ -1,10 +1,13 @@
 domain: INFRA
 type: GCPINTERNALLOADBALANCER
 goldenTags:
-  - gcp.projectId
-  - gcp.zone
+- gcp.projectId
+- gcp.zone
 compositeMetrics:
   summaryMetrics:
   - summary_metrics.yml
   goldenMetrics:
   - golden_metrics.yml
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true

--- a/definitions/infra-gcpkubernetescontainer/definition.yml
+++ b/definitions/infra-gcpkubernetescontainer/definition.yml
@@ -3,3 +3,6 @@ type: GCPKUBERNETESCONTAINER
 compositeMetrics:
   summaryMetrics:
   - summary_metrics.yml
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true

--- a/definitions/infra-gcpkubernetesnode/definition.yml
+++ b/definitions/infra-gcpkubernetesnode/definition.yml
@@ -3,3 +3,6 @@ type: GCPKUBERNETESNODE
 compositeMetrics:
   summaryMetrics:
   - summary_metrics.yml
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true

--- a/definitions/infra-gcpkubernetespod/definition.yml
+++ b/definitions/infra-gcpkubernetespod/definition.yml
@@ -1,2 +1,5 @@
 domain: INFRA
 type: GCPKUBERNETESPOD
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true

--- a/definitions/infra-gcpmemcachememcachenode/definition.yml
+++ b/definitions/infra-gcpmemcachememcachenode/definition.yml
@@ -6,3 +6,6 @@ goldenTags:
 compositeMetrics:
   goldenMetrics:
   - golden_metrics.yml
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true

--- a/definitions/infra-gcppubsubsubscription/definition.yml
+++ b/definitions/infra-gcppubsubsubscription/definition.yml
@@ -3,3 +3,6 @@ type: GCPPUBSUBSUBSCRIPTION
 compositeMetrics:
   summaryMetrics:
   - summary_metrics.yml
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true

--- a/definitions/infra-gcppubsubtopic/definition.yml
+++ b/definitions/infra-gcppubsubtopic/definition.yml
@@ -3,3 +3,6 @@ type: GCPPUBSUBTOPIC
 compositeMetrics:
   summaryMetrics:
   - summary_metrics.yml
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true

--- a/definitions/infra-gcpredisinstance/definition.yml
+++ b/definitions/infra-gcpredisinstance/definition.yml
@@ -6,3 +6,6 @@ goldenTags:
 compositeMetrics:
   goldenMetrics:
   - golden_metrics.yml
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true

--- a/definitions/infra-gcpredisredisinstance/definition.yml
+++ b/definitions/infra-gcpredisredisinstance/definition.yml
@@ -1,2 +1,5 @@
 domain: INFRA
 type: GCPREDISREDISINSTANCE
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true

--- a/definitions/infra-gcproutercloudrouter/definition.yml
+++ b/definitions/infra-gcproutercloudrouter/definition.yml
@@ -1,2 +1,5 @@
 domain: INFRA
 type: GCPROUTERCLOUDROUTER
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true

--- a/definitions/infra-gcprouternatgateway/definition.yml
+++ b/definitions/infra-gcprouternatgateway/definition.yml
@@ -1,2 +1,5 @@
 domain: INFRA
 type: GCPROUTERNATGATEWAY
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true

--- a/definitions/infra-gcprunrevision/definition.yml
+++ b/definitions/infra-gcprunrevision/definition.yml
@@ -1,2 +1,5 @@
 domain: INFRA
 type: GCPRUNREVISION
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true

--- a/definitions/infra-gcpspannerdatabase/definition.yml
+++ b/definitions/infra-gcpspannerdatabase/definition.yml
@@ -8,3 +8,6 @@ compositeMetrics:
   - summary_metrics.yml
   goldenMetrics:
   - golden_metrics.yml
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true

--- a/definitions/infra-gcpspannerinstance/definition.yml
+++ b/definitions/infra-gcpspannerinstance/definition.yml
@@ -1,10 +1,13 @@
 domain: INFRA
 type: GCPSPANNERINSTANCE
 goldenTags:
-  - gcp.projectId
-  - gcp.zone
+- gcp.projectId
+- gcp.zone
 compositeMetrics:
   summaryMetrics:
   - summary_metrics.yml
   goldenMetrics:
   - golden_metrics.yml
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true

--- a/definitions/infra-gcpstoragebucket/definition.yml
+++ b/definitions/infra-gcpstoragebucket/definition.yml
@@ -1,10 +1,13 @@
 domain: INFRA
 type: GCPSTORAGEBUCKET
 goldenTags:
-  - gcp.projectId
-  - gcp.zone
+- gcp.projectId
+- gcp.zone
 compositeMetrics:
   summaryMetrics:
   - summary_metrics.yml
   goldenMetrics:
   - golden_metrics.yml
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true

--- a/definitions/infra-gcptcpsslproxyloadbalancer/definition.yml
+++ b/definitions/infra-gcptcpsslproxyloadbalancer/definition.yml
@@ -1,2 +1,5 @@
 domain: INFRA
 type: GCPTCPSSLPROXYLOADBALANCER
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true

--- a/definitions/infra-gcpvirtualmachinedisk/definition.yml
+++ b/definitions/infra-gcpvirtualmachinedisk/definition.yml
@@ -1,2 +1,5 @@
 domain: INFRA
 type: GCPVIRTUALMACHINEDISK
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true

--- a/definitions/infra-gcpvpcaccessconnector/definition.yml
+++ b/definitions/infra-gcpvpcaccessconnector/definition.yml
@@ -1,2 +1,5 @@
 domain: INFRA
 type: GCPVPCACCESSCONNECTOR
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true

--- a/definitions/infra-github_actions/definition.yml
+++ b/definitions/infra-github_actions/definition.yml
@@ -1,2 +1,5 @@
 domain: INFRA
 type: GITHUB_ACTIONS
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true

--- a/definitions/infra-github_api/definition.yml
+++ b/definitions/infra-github_api/definition.yml
@@ -1,2 +1,5 @@
 domain: INFRA
 type: GITHUB_API
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true

--- a/definitions/infra-github_repo/definition.yml
+++ b/definitions/infra-github_repo/definition.yml
@@ -1,2 +1,5 @@
 domain: INFRA
 type: GITHUB_REPO
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true

--- a/definitions/infra-host/definition.yml
+++ b/definitions/infra-host/definition.yml
@@ -17,3 +17,6 @@ compositeMetrics:
   - golden_metrics.yml
   summaryMetrics:
   - summary_metrics.yml
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true

--- a/definitions/infra-kafkabroker/definition.yml
+++ b/definitions/infra-kafkabroker/definition.yml
@@ -1,10 +1,13 @@
 domain: INFRA
 type: KAFKABROKER
 goldenTags:
-  - kafka.clusterName
-  - kafka.brokerId
+- kafka.clusterName
+- kafka.brokerId
 compositeMetrics:
   goldenMetrics:
   - golden_metrics.yml
   summaryMetrics:
   - summary_metrics.yml
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true

--- a/definitions/infra-kafkatopic/definition.yml
+++ b/definitions/infra-kafkatopic/definition.yml
@@ -1,2 +1,5 @@
 domain: INFRA
 type: KAFKATOPIC
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true

--- a/definitions/infra-kubernetes_apiserver/definition.yml
+++ b/definitions/infra-kubernetes_apiserver/definition.yml
@@ -8,13 +8,13 @@ synthesis:
   - attribute: metricName
     prefix: apiserver_
   tags:
-    'label.topology.kubernetes.io/region':
-    'label.topology.kubernetes.io/zone':
-    'label.eks.amazonaws.com/compute-type':
-    'k8s.cluster.name':
-    'label.kubernetes.io/arch':
-    'label.kubernetes.io/hostname':
-    'label.kubernetes.io/os':
+    label.topology.kubernetes.io/region: null
+    label.topology.kubernetes.io/zone: null
+    label.eks.amazonaws.com/compute-type: null
+    k8s.cluster.name: null
+    label.kubernetes.io/arch: null
+    label.kubernetes.io/hostname: null
+    label.kubernetes.io/os: null
 goldenTags:
 - label.kubernetes.io/os
 compositeMetrics:
@@ -22,3 +22,6 @@ compositeMetrics:
   - golden_metrics.yml
   summaryMetrics:
   - summary_metrics.yml
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true

--- a/definitions/infra-kubernetescluster/definition.yml
+++ b/definitions/infra-kubernetescluster/definition.yml
@@ -1,2 +1,5 @@
 domain: INFRA
 type: KUBERNETESCLUSTER
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true

--- a/definitions/infra-memcachedinstance/definition.yml
+++ b/definitions/infra-memcachedinstance/definition.yml
@@ -3,3 +3,6 @@ type: MEMCACHEDINSTANCE
 compositeMetrics:
   summaryMetrics:
   - summary_metrics.yml
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true

--- a/definitions/infra-mssqlinstance/definition.yml
+++ b/definitions/infra-mssqlinstance/definition.yml
@@ -1,10 +1,13 @@
 domain: INFRA
 type: MSSQLINSTANCE
 goldenTags:
-  - mssql.host
-  - mssql.instance
+- mssql.host
+- mssql.instance
 compositeMetrics:
   goldenMetrics:
   - golden_metrics.yml
   summaryMetrics:
   - summary_metrics.yml
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true

--- a/definitions/infra-mysqlnode/definition.yml
+++ b/definitions/infra-mysqlnode/definition.yml
@@ -1,13 +1,16 @@
 domain: INFRA
 type: MYSQLNODE
 goldenTags:
-  - mysql.port
-  - mysql.version
-  - mysql.edition
-  - mysql.hostname
-  - mysql.clusterNodeType
+- mysql.port
+- mysql.version
+- mysql.edition
+- mysql.hostname
+- mysql.clusterNodeType
 compositeMetrics:
   goldenMetrics:
   - golden_metrics.yml
   summaryMetrics:
   - summary_metrics.yml
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true

--- a/definitions/infra-nginxserver/definition.yml
+++ b/definitions/infra-nginxserver/definition.yml
@@ -1,12 +1,15 @@
 domain: INFRA
 type: NGINXSERVER
 goldenTags:
-  - nginx.port
-  - nginx.version
-  - nginx.edition
-  - nginx.hostname
+- nginx.port
+- nginx.version
+- nginx.edition
+- nginx.hostname
 compositeMetrics:
   goldenMetrics:
   - golden_metrics.yml
   summaryMetrics:
   - summary_metrics.yml
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true

--- a/definitions/infra-oracledbinstance/definition.yml
+++ b/definitions/infra-oracledbinstance/definition.yml
@@ -6,3 +6,6 @@ compositeMetrics:
   - golden_metrics.yml
   summaryMetrics:
   - summary_metrics.yml
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true

--- a/definitions/infra-postgresqlinstance/definition.yml
+++ b/definitions/infra-postgresqlinstance/definition.yml
@@ -1,9 +1,12 @@
 domain: INFRA
 type: POSTGRESQLINSTANCE
 goldenTags:
-  - postgres.host
+- postgres.host
 compositeMetrics:
   goldenMetrics:
   - golden_metrics.yml
   summaryMetrics:
   - summary_metrics.yml
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true

--- a/definitions/infra-rabbitmqcluster/definition.yml
+++ b/definitions/infra-rabbitmqcluster/definition.yml
@@ -2,3 +2,6 @@ domain: INFRA
 type: RABBITMQCLUSTER
 goldenTags:
 - account
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true

--- a/definitions/infra-rabbitmqexchange/definition.yml
+++ b/definitions/infra-rabbitmqexchange/definition.yml
@@ -7,3 +7,6 @@ compositeMetrics:
   - golden_metrics.yml
   summaryMetrics:
   - summary_metrics.yml
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true

--- a/definitions/infra-rabbitmqnode/definition.yml
+++ b/definitions/infra-rabbitmqnode/definition.yml
@@ -7,3 +7,6 @@ compositeMetrics:
   - golden_metrics.yml
   summaryMetrics:
   - summary_metrics.yml
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true

--- a/definitions/infra-rabbitmqqueue/definition.yml
+++ b/definitions/infra-rabbitmqqueue/definition.yml
@@ -7,3 +7,6 @@ compositeMetrics:
   - golden_metrics.yml
   summaryMetrics:
   - summary_metrics.yml
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true

--- a/definitions/infra-ravendb_database/definition.yml
+++ b/definitions/infra-ravendb_database/definition.yml
@@ -1,2 +1,5 @@
 domain: INFRA
 type: RAVENDB_DATABASE
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true

--- a/definitions/infra-ravendb_node/definition.yml
+++ b/definitions/infra-ravendb_node/definition.yml
@@ -1,2 +1,5 @@
 domain: INFRA
 type: RAVENDB_NODE
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true

--- a/definitions/infra-redisinstance/definition.yml
+++ b/definitions/infra-redisinstance/definition.yml
@@ -1,12 +1,15 @@
 domain: INFRA
 type: REDISINSTANCE
 goldenTags:
-  - redis.port
-  - redis.hostname
-  - redis.version
-  - redis.clusterRole
+- redis.port
+- redis.hostname
+- redis.version
+- redis.clusterRole
 compositeMetrics:
   goldenMetrics:
   - golden_metrics.yml
   summaryMetrics:
   - summary_metrics.yml
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true

--- a/definitions/infra-varnishinstance/definition.yml
+++ b/definitions/infra-varnishinstance/definition.yml
@@ -3,3 +3,6 @@ type: VARNISHINSTANCE
 compositeMetrics:
   summaryMetrics:
   - summary_metrics.yml
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true

--- a/definitions/infra-vspherecluster/definition.yml
+++ b/definitions/infra-vspherecluster/definition.yml
@@ -1,12 +1,15 @@
 domain: INFRA
 type: VSPHERECLUSTER
 goldenTags:
-  - vsphere.clusterDatacenterLocation
-  - vsphere.clusterDatacenterName
-  - vsphere.clusterHostList
-  - vsphere.clusterDatastoreList
+- vsphere.clusterDatacenterLocation
+- vsphere.clusterDatacenterName
+- vsphere.clusterHostList
+- vsphere.clusterDatastoreList
 compositeMetrics:
   goldenMetrics:
   - golden_metrics.yml
   summaryMetrics:
   - summary_metrics.yml
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true

--- a/definitions/infra-vspheredatacenter/definition.yml
+++ b/definitions/infra-vspheredatacenter/definition.yml
@@ -6,3 +6,6 @@ compositeMetrics:
   - golden_metrics.yml
   summaryMetrics:
   - summary_metrics.yml
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true

--- a/definitions/infra-vspheredatastore/definition.yml
+++ b/definitions/infra-vspheredatastore/definition.yml
@@ -6,3 +6,6 @@ compositeMetrics:
   - golden_metrics.yml
   summaryMetrics:
   - summary_metrics.yml
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true

--- a/definitions/infra-vspherehost/definition.yml
+++ b/definitions/infra-vspherehost/definition.yml
@@ -1,14 +1,17 @@
 domain: INFRA
 type: VSPHEREHOST
 goldenTags:
-  - vsphere.hostClusterName
-  - vsphere.hostOverallStatus
-  - vsphere.hostDatacenterName
-  - vsphere.hostResourcePoolNameList
-  - vsphere.hostDatastoreNameList
-  - vsphere.hostHypervisorHostname
+- vsphere.hostClusterName
+- vsphere.hostOverallStatus
+- vsphere.hostDatacenterName
+- vsphere.hostResourcePoolNameList
+- vsphere.hostDatastoreNameList
+- vsphere.hostHypervisorHostname
 compositeMetrics:
   goldenMetrics:
   - golden_metrics.yml
   summaryMetrics:
   - summary_metrics.yml
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true

--- a/definitions/infra-vsphereresourcepool/definition.yml
+++ b/definitions/infra-vsphereresourcepool/definition.yml
@@ -6,3 +6,6 @@ compositeMetrics:
   - golden_metrics.yml
   summaryMetrics:
   - summary_metrics.yml
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true

--- a/definitions/infra-vspherevm/definition.yml
+++ b/definitions/infra-vspherevm/definition.yml
@@ -1,14 +1,17 @@
 domain: INFRA
 type: VSPHEREVM
 goldenTags:
-  - vsphere.vmClusterName
-  - vsphere.vmDatacenterName
-  - vsphere.vmHypervisorHostname
-  - vsphere.vmResourcePoolName
-  - vsphere.vmDatastoreNameList
-  - vsphere.vmVmHostname
+- vsphere.vmClusterName
+- vsphere.vmDatacenterName
+- vsphere.vmHypervisorHostname
+- vsphere.vmResourcePoolName
+- vsphere.vmDatastoreNameList
+- vsphere.vmVmHostname
 compositeMetrics:
   goldenMetrics:
   - golden_metrics.yml
   summaryMetrics:
   - summary_metrics.yml
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true

--- a/definitions/infra-win_service/definition.yml
+++ b/definitions/infra-win_service/definition.yml
@@ -3,3 +3,6 @@ type: WIN_SERVICE
 compositeMetrics:
   summaryMetrics:
   - summary_metrics.yml
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true

--- a/definitions/infra-windowsservice/definition.yml
+++ b/definitions/infra-windowsservice/definition.yml
@@ -3,3 +3,6 @@ type: WINDOWSSERVICE
 compositeMetrics:
   summaryMetrics:
   - summary_metrics.yml
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true

--- a/definitions/mobile-application/definition.yml
+++ b/definitions/mobile-application/definition.yml
@@ -6,3 +6,6 @@ compositeMetrics:
   - golden_metrics.yml
   summaryMetrics:
   - summary_metrics.yml
+configuration:
+  entityExpirationTime: QUARTERLY
+  alertable: true

--- a/definitions/nr1-workload/definition.yml
+++ b/definitions/nr1-workload/definition.yml
@@ -4,3 +4,6 @@ goldenTags:
 - Team
 - Environment
 - env
+configuration:
+  entityExpirationTime: MANUAL
+  alertable: true

--- a/definitions/synth-monitor/definition.yml
+++ b/definitions/synth-monitor/definition.yml
@@ -9,3 +9,6 @@ goldenTags:
 compositeMetrics:
   goldenMetrics:
   - golden_metrics.yml
+configuration:
+  entityExpirationTime: EIGHT_DAYS
+  alertable: true

--- a/definitions/synth-secure_cred/definition.yml
+++ b/definitions/synth-secure_cred/definition.yml
@@ -1,2 +1,5 @@
 domain: SYNTH
 type: SECURE_CRED
+configuration:
+  entityExpirationTime: EIGHT_DAYS
+  alertable: false

--- a/definitions/viz-dashboard/definition.yml
+++ b/definitions/viz-dashboard/definition.yml
@@ -1,2 +1,5 @@
 domain: VIZ
 type: DASHBOARD
+configuration:
+  entityExpirationTime: EIGHT_DAYS
+  alertable: false


### PR DESCRIPTION
### Relevant information

Migrate the `entityExpirationTime` and `alertable ` configuration for all migrated entitities.
