### PR TITLE
Fix typo on summary metrics of MOBILE|APPLICATION

### DIFF
--- a/definitions/mobile-application/summary_metrics.yml
+++ b/definitions/mobile-application/summary_metrics.yml
@@ -91,7 +91,7 @@ httpResponseTimeAverage:
     eventId: appId
     eventObjectId: DOMAIN_IDS
   hidden: true
-newtworkFailureRate:
-  title: Newtwork Failure Rate
+networkFailureRate:
+  title: Network Failure Rate
   unit: PERCENTAGE
   derive: (100 * @networkFailureCount) / @totalNetworkCount


### PR DESCRIPTION
### Relevant information

Fixed a typo on the summary metrics of mobile applications: `newtwork` to `network`.

### Checklist

* [x] I've read the guidelines and understand the acceptance criteria.
* [ ] The value of the attribute marked as `identifier` will be unique and valid. 
* [ ] I've confirmed that my entity type wasn't already defined. If it is I'm providing an
 explanation above.
