### PR TITLE
Add entityTagName configuration to tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,15 +176,15 @@ If you want to override all the values with the new one you can configure `multi
 
 An example of this is `INFRA-CONTAINER` where the tag `container.state` will always display the last state (`running`, `stopped`, etc) instead of a list of all the states the entity has gone through.
 
-You can also configure the key-name that you want for the tags we synthesize from your telemetry attributes. 
-By default, the tag-keys are the names of the attributes you specify on the tags section, but you can specify a different key-name using the `writeAs` field. 
+You can also configure the tag name that you want for the entity tags we synthesize from your telemetry attributes. 
+By default, the entity tag names are equal to the attributes you specify on the `tags` section, but you can specify a different tag name using the `entityTagName` field. 
 
 In the example below if `attributeNameB` is present on the telemetry, a tag with key `preferredTagName` and the value of the attribute will be added to the entity. For `attributeNameC` a tag would be created with `attributeNameC` as the key. 
 
 ```yaml
   tags:
     attributeNameB:
-      writeAs: preferredTagName,
+      entityTagName: preferredTagName,
     attributeNameC:
 ```
 

--- a/README.md
+++ b/README.md
@@ -176,18 +176,20 @@ If you want to override all the values with the new one you can configure `multi
 
 An example of this is `INFRA-CONTAINER` where the tag `container.state` will always display the last state (`running`, `stopped`, etc) instead of a list of all the states the entity has gone through.
 
-You can also configure the tag name that you want for the entity tags we synthesize from your telemetry attributes. 
-By default, the entity tag names are equal to the attributes you specify on the `tags` section, but you can specify a different tag name using the `entityTagName` field. 
+You can also configure the tag name that you want for the entity tags we synthesize. By default, the entity tag names are equal to the telemetry attributes you specify on the `tags` section, but you can specify a different tag name using the `entityTagName` field.  
 
 In the example below if `attributeNameB` is present on the telemetry, a tag with key `preferredTagName` and the value of the attribute will be added to the entity. For `attributeNameC` a tag would be created with `attributeNameC` as the key. 
 
 ```yaml
   tags:
     attributeNameB:
-      entityTagName: preferredTagName,
+      entityTagName: preferredTagName
     attributeNameC:
 ```
 
+This explicit naming can be used to guarantee consistency when you have telemetry from different sources for a single entity, since they are likely to use different attribute names for what would conceptually be the same entity tag. Otherwise, our advice is to use the default naming.
+
+An example of an entity definition where the `entityTagName` is needed and correctly used is the [INFRA-CONTAINER](https://github.com/newrelic-experimental/entity-synthesis-definitions/blob/main/definitions/infra-container/definition.yml) type. 
 
 #### Golden tags
 

--- a/README.md
+++ b/README.md
@@ -176,6 +176,18 @@ If you want to override all the values with the new one you can configure `multi
 
 An example of this is `INFRA-CONTAINER` where the tag `container.state` will always display the last state (`running`, `stopped`, etc) instead of a list of all the states the entity has gone through.
 
+You can also configure the key-name that you want for the tags we synthesize from your telemetry attributes. 
+By default, the tag-keys are the names of the attributes you specify on the tags section, but you can specify a different key-name using the `writeAs` field. 
+
+In the example below if `attributeNameB` is present on the telemetry, a tag with key `preferredTagName` and the value of the attribute will be added to the entity. For `attributeNameC` a tag would be created with `attributeNameC` as the key. 
+
+```yaml
+  tags:
+    attributeNameB:
+      writeAs: preferredTagName,
+    attributeNameC:
+```
+
 
 #### Golden tags
 

--- a/README.md
+++ b/README.md
@@ -159,12 +159,12 @@ We support the following conditions over telemetry attributes and their values:
 
 ##### Tags
 
-The `tags` field accepts an array of metric's attributes that can be used to generate tags for the entities of the defined DOMAIN and TYPE.
-During synthesis, the tags will be created using the attribute name as key and its value as the tag value. 
+The `tags` field accepts a map of metric attributes to entity tag configurations that can be used to generate tags for the entities of the defined DOMAIN and TYPE.
+During synthesis, the tags will be created using the attribute name as key and its value as the tag value. The tag configurations are optional and can be left empty. 
 
 If some of the tags' attributes are not present on the telemetry message received, the entity will still be synthesized with the available tags (if any).
 
-By default an entity tag will contain all the values seen for this attribute in the telemetry.
+By default, an entity tag will contain all the values seen for this attribute in the telemetry.
 If you want to override all the values with the new one you can configure `multiValue: false` for that specific tag.
 
 ```yaml

--- a/definitions/infra-container/definition.yml
+++ b/definitions/infra-container/definition.yml
@@ -11,7 +11,7 @@ synthesis:
     tags:
       container.state:
       docker.state:
-        writeAs: container.state
+        entityTagName: container.state
       docker.containerId:
       docker.shortContainerId:
       docker.imageName:
@@ -29,7 +29,7 @@ synthesis:
     - attribute: k8s.containerId
     tags:
       k8s.status:
-        writeAs: container.state
+        entityTagName: container.state
       k8s.clusterName:
       k8s.namespaceName:
       k8s.podName:
@@ -44,9 +44,9 @@ synthesis:
       label.kubernetes.io/os:
       # This is for OpenTelemetry. Verify if we need to respect tag priority since they alias to the same tagName as others above
       k8s.cluster.name:
-        writeAs: k8s.clusterName
+        entityTagName: k8s.clusterName
       k8s.namespace.name:
-        writeAs: k8s.namespaceName
+        entityTagName: k8s.namespaceName
   tags:
     newrelic.integrationName:
     newrelic.integrationVersion:
@@ -55,9 +55,9 @@ synthesis:
     instrumentation.name:
     # For OpenTelemetry
     telemetry.sdk.name:
-      writeAs: instrumentation.provider
+      entityTagName: instrumentation.provider
     telemetry.sdk.language:
-      writeAs: language
+      entityTagName: language
     # AWS tags
     aws.region:
     aws.ec2.instanceType:

--- a/definitions/infra-container/definition.yml
+++ b/definitions/infra-container/definition.yml
@@ -9,7 +9,8 @@ synthesis:
     - attribute: docker.containerId
     tags:
       container.state:
-      docker.state: # Missing alias
+      docker.state:
+        writeAs: container.state
       docker.containerId:
       docker.shortContainerId:
       docker.imageName:
@@ -26,7 +27,8 @@ synthesis:
     conditions:
     - attribute: k8s.containerId
     tags:
-      k8s.status: # Missing alias
+      k8s.status:
+        writeAs: container.state
       k8s.clusterName:
       k8s.namespaceName:
       k8s.podName:
@@ -39,9 +41,11 @@ synthesis:
       label.kubernetes.io/arch:
       label.kubernetes.io/hostname:
       label.kubernetes.io/os:
-      # This is for OTEL. Verify if we need to respect tag priority since they alias to the same tagName as `k8s.clusterName`
-      k8s.cluster.name: # Missing alias
-      k8s.namespace.name: # Missing alias
+      # This is for OTEL. Verify if we need to respect tag priority since they alias to the same tagName as others above
+      k8s.cluster.name:
+        writeAs: k8s.clusterName
+      k8s.namespace.name:
+        writeAs: k8s.namespaceName
   tags:
     newrelic.integrationName:
     newrelic.integrationVersion:

--- a/definitions/infra-container/definition.yml
+++ b/definitions/infra-container/definition.yml
@@ -1,5 +1,6 @@
 domain: INFRA
 type: CONTAINER
+
 synthesis:
   rules:
   - identifier: entity.id
@@ -41,7 +42,7 @@ synthesis:
       label.kubernetes.io/arch:
       label.kubernetes.io/hostname:
       label.kubernetes.io/os:
-      # This is for OTEL. Verify if we need to respect tag priority since they alias to the same tagName as others above
+      # This is for OpenTelemetry. Verify if we need to respect tag priority since they alias to the same tagName as others above
       k8s.cluster.name:
         writeAs: k8s.clusterName
       k8s.namespace.name:
@@ -50,6 +51,17 @@ synthesis:
     newrelic.integrationName:
     newrelic.integrationVersion:
     newrelic.agentVersion:
+    instrumentation.provider:
+    instrumentation.name:
+    # For OpenTelemetry
+    telemetry.sdk.name:
+      writeAs: instrumentation.provider
+    telemetry.sdk.language:
+      writeAs: language
+    # AWS tags
+    aws.region:
+    aws.ec2.instanceType:
+
 goldenTags:
 - environment
 - container.state

--- a/definitions/infra-container/definition.yml
+++ b/definitions/infra-container/definition.yml
@@ -51,8 +51,6 @@ synthesis:
     newrelic.integrationName:
     newrelic.integrationVersion:
     newrelic.agentVersion:
-    instrumentation.provider:
-    instrumentation.name:
     # For OpenTelemetry
     telemetry.sdk.name:
       entityTagName: instrumentation.provider

--- a/definitions/infra-container/definition.yml
+++ b/definitions/infra-container/definition.yml
@@ -65,11 +65,13 @@ synthesis:
 goldenTags:
 - environment
 - container.state
+
 compositeMetrics:
   goldenMetrics:
   - golden_metrics.yml
   summaryMetrics:
   - summary_metrics.yml
+
 configuration:
   entityExpirationTime: DAILY
   alertable: true

--- a/docs/example-entity-definition.yml
+++ b/docs/example-entity-definition.yml
@@ -31,7 +31,7 @@ synthesis:
       multiValue: false
     attributeNameD:
       # The key of the tag to be created with the value of the provided attribute. Defaults to the attribute name.
-      writeAs: preferredTagName
+      entityTagName: preferredTagName
 
 # Template that can be used to generate a dashboard for the entity.
 # If your telemetry comes from different providers you can specify a dashboard for each one of them, otherwise you can just use `newRelic`

--- a/docs/example-entity-definition.yml
+++ b/docs/example-entity-definition.yml
@@ -26,6 +26,12 @@ synthesis:
   tags:
     attributeNameB:
     attributeNameC:
+      # If set to true, an entity tag contains all the values seen for this attribute in the telemetry.
+      # If set to false it will only contain the last one. Defaults to true
+      multiValue: false
+    attributeNameD:
+      # The key of the tag to be created with the value of the provided attribute. Defaults to the attribute name.
+      writeAs: preferredTagName
 
 # Template that can be used to generate a dashboard for the entity.
 # If your telemetry comes from different providers you can specify a dashboard for each one of them, otherwise you can just use `newRelic`

--- a/validator/schemas/entity-schema-v1.json
+++ b/validator/schemas/entity-schema-v1.json
@@ -184,14 +184,7 @@
             "tags": {
               "$id": "#/synthesis/rules/items/tags",
               "type": "object",
-              "title": "An array of tags.",
               "description": "Tags associated to the entity that can be extracted from the metrics information received.",
-              "examples": [
-                [
-                  "attributeName",
-                  "attributeName2"
-                ]
-              ],
               "additionalItems": false,
               "items": {
                 "$id": "#/properties/tags/items",
@@ -202,15 +195,24 @@
                     "title": "Tag configuration",
                     "description": "The configuration of the tag being synthesized",
                     "examples": [
-                      {"multiValue": "false"}
+                      {
+                        "multiValue": "false",
+                        "writeAs": "intendedTagName"
+                      }
                     ],
                     "properties": {
                       "multiValue": {
                         "$id": "#/properties/tags/items/anyOf/0/properties/multiValue",
                         "type": "boolean",
                         "title": "If the tag should allow a list of string values or a single string value"
+                      },
+                      "writeAs": {
+                        "$id": "#/properties/tags/items/anyOf/0/properties/writeAs",
+                        "type": "string",
+                        "title": "The key of the tag to be created with the value of the provided attribute"
                       }
-                    }
+                    },
+                    "additionalItems": false
                   }
                 ]
               }

--- a/validator/schemas/entity-schema-v1.json
+++ b/validator/schemas/entity-schema-v1.json
@@ -197,7 +197,7 @@
                     "examples": [
                       {
                         "multiValue": "false",
-                        "writeAs": "intendedTagName"
+                        "entityTagName": "intendedTagName"
                       }
                     ],
                     "properties": {
@@ -206,8 +206,8 @@
                         "type": "boolean",
                         "title": "If the tag should allow a list of string values or a single string value"
                       },
-                      "writeAs": {
-                        "$id": "#/properties/tags/items/anyOf/0/properties/writeAs",
+                      "entityTagName": {
+                        "$id": "#/properties/tags/items/anyOf/0/properties/entityTagName",
                         "type": "string",
                         "title": "The key of the tag to be created with the value of the provided attribute"
                       }


### PR DESCRIPTION
### Relevant information

Add entityTagName configuration to tags so that users can specify their desired tag key. If not specified we use the default (the attribute name)
