### PR TITLE
adding ext-router entity definition and metrics

### DIFF
--- a/definitions/ext-router/definition.yml
+++ b/definitions/ext-router/definition.yml
@@ -8,10 +8,8 @@ synthesis:
   encodeIdentifierInGUID: true
 
   conditions:
-    - attribute: metricName
-      prefix: kentik
     - attribute: provider
-      value: router
+      value: kentik-router
 
   tags:
     src_addr:

--- a/definitions/ext-router/definition.yml
+++ b/definitions/ext-router/definition.yml
@@ -1,0 +1,26 @@
+domain: EXT
+# Network Router devices from Kentik using Metric API
+# Leaving this ambiguous to allow future technical partners to use the same entity type with additional conditions
+type: ROUTER
+synthesis:
+  name: device_name
+  identifier: device_name
+  encodeIdentifierInGUID: true
+
+  conditions:
+    - attribute: metricName
+      prefix: kentik
+    - attribute: provider
+      value: router
+
+  tags:
+    src_addr:
+
+compositeMetrics:
+  goldenMetric:
+    - golden_metrics.yml
+  summaryMetrics:
+    - summary_metrics.yml
+
+goldenTags:
+  - src_addr

--- a/definitions/ext-router/definition.yml
+++ b/definitions/ext-router/definition.yml
@@ -8,17 +8,17 @@ synthesis:
   encodeIdentifierInGUID: true
 
   conditions:
-    - attribute: provider
-      value: kentik-router
+  - attribute: provider
+    value: kentik-router
 
   tags:
     src_addr:
 
 compositeMetrics:
-  goldenMetric:
-    - golden_metrics.yml
+  goldenMetrics:
+  - golden_metrics.yml
   summaryMetrics:
-    - summary_metrics.yml
+  - summary_metrics.yml
 
 goldenTags:
-  - src_addr
+- src_addr

--- a/definitions/ext-router/golden_metrics.yml
+++ b/definitions/ext-router/golden_metrics.yml
@@ -3,25 +3,25 @@ cpuUtilization:
   query:
     select: average(kentik.snmp.CPU) AS 'CPU Utilization'
     from: Metric
-    where: "provider = 'router'"
+    where: "provider = 'kentik-router'"
 
 memoryUtilization:
   title: Memory Utilization (%)
   query:
     select: average(kentik.snmp.MemoryUtilization) AS 'Memory Utilization'
     from: Metric
-    where: "provider = 'router'"
+    where: "provider = 'kentik-router'"
 
 receiveErrors:
   title: Aggregate Receive Errors (count)
   query:
     select: sum(kentik.snmp.ifInErrors) AS 'Receive Errors'
     from: Metric
-    where: "provider = 'router'"
+    where: "provider = 'kentik-router'"
 
 transmitErrors:
   title: Aggregate Transmit Errors (count)
   query:
     select: sum(kentik.snmp.ifOutErrors) AS 'Transmit Errors'
     from: Metric
-    where: "provider = 'router'"
+    where: "provider = 'kentik-router'"

--- a/definitions/ext-router/golden_metrics.yml
+++ b/definitions/ext-router/golden_metrics.yml
@@ -1,27 +1,27 @@
 cpuUtilization:
   title: CPU Utilization (%)
   query:
-    select: average(kentik.snmp.CPU) AS 'CPU Utilization'
+    select: average(kentik.snmp.CPU)
     from: Metric
     where: "provider = 'kentik-router'"
 
 memoryUtilization:
   title: Memory Utilization (%)
   query:
-    select: average(kentik.snmp.MemoryUtilization) AS 'Memory Utilization'
+    select: average(kentik.snmp.MemoryUtilization)
     from: Metric
     where: "provider = 'kentik-router'"
 
 receiveErrors:
   title: Aggregate Receive Errors (count)
   query:
-    select: sum(kentik.snmp.ifInErrors) AS 'Receive Errors'
+    select: sum(kentik.snmp.ifInErrors)
     from: Metric
     where: "provider = 'kentik-router'"
 
 transmitErrors:
   title: Aggregate Transmit Errors (count)
   query:
-    select: sum(kentik.snmp.ifOutErrors) AS 'Transmit Errors'
+    select: sum(kentik.snmp.ifOutErrors)
     from: Metric
     where: "provider = 'kentik-router'"

--- a/definitions/ext-router/golden_metrics.yml
+++ b/definitions/ext-router/golden_metrics.yml
@@ -1,0 +1,27 @@
+cpuUtilization:
+  title: CPU Utilization (%)
+  query:
+    select: average(kentik.snmp.CPU) AS 'CPU Utilization'
+    from: Metric
+    where: "provider = 'router'"
+
+memoryUtilization:
+  title: Memory Utilization (%)
+  query:
+    select: average(kentik.snmp.MemoryUtilization) AS 'Memory Utilization'
+    from: Metric
+    where: "provider = 'router'"
+
+receiveErrors:
+  title: Aggregate Receive Errors (count)
+  query:
+    select: sum(kentik.snmp.ifInErrors) AS 'Receive Errors'
+    from: Metric
+    where: "provider = 'router'"
+
+transmitErrors:
+  title: Aggregate Transmit Errors (count)
+  query:
+    select: sum(kentik.snmp.ifOutErrors) AS 'Transmit Errors'
+    from: Metric
+    where: "provider = 'router'"

--- a/definitions/ext-router/summary_metrics.yml
+++ b/definitions/ext-router/summary_metrics.yml
@@ -10,7 +10,7 @@ cpuUtilization:
   query:
     select: average(kentik.snmp.CPU) AS 'CPU Utilization'
     from: Metric
-    where: "provider = 'router'"
+    where: "provider = 'kentik-router'"
     eventId: entityGuid
 
 memoryUtilization:
@@ -19,7 +19,7 @@ memoryUtilization:
   query:
     select: average(kentik.snmp.MemoryUtilization) AS 'Memory Utilization'
     from: Metric
-    where: "provider = 'router'"
+    where: "provider = 'kentik-router'"
     eventId: entityGuid
 
 receiveErrors:
@@ -28,7 +28,7 @@ receiveErrors:
   query:
     select: sum(kentik.snmp.ifInErrors) AS 'Receive Errors'
     from: Metric
-    where: "provider = 'router'"
+    where: "provider = 'kentik-router'"
     eventId: entityGuid
 
 transmitErrors:
@@ -37,5 +37,5 @@ transmitErrors:
   query:
     select: sum(kentik.snmp.ifOutErrors) AS 'Transmit Errors'
     from: Metric
-    where: "provider = 'router'"
+    where: "provider = 'kentik-router'"
     eventId: entityGuid

--- a/definitions/ext-router/summary_metrics.yml
+++ b/definitions/ext-router/summary_metrics.yml
@@ -8,7 +8,7 @@ cpuUtilization:
   title: CPU Utilization (%)
   unit: PERCENTAGE
   query:
-    select: average(kentik.snmp.CPU) AS 'CPU Utilization'
+    select: average(kentik.snmp.CPU)
     from: Metric
     where: "provider = 'kentik-router'"
     eventId: entityGuid
@@ -17,25 +17,25 @@ memoryUtilization:
   title: Memory Utilization (%)
   unit: PERCENTAGE
   query:
-    select: average(kentik.snmp.MemoryUtilization) AS 'Memory Utilization'
+    select: average(kentik.snmp.MemoryUtilization)
     from: Metric
     where: "provider = 'kentik-router'"
     eventId: entityGuid
 
 receiveErrors:
-  title: Aggregate Receive Errors (count)
+  title: Receive Errors (count)
   unit: COUNT
   query:
-    select: sum(kentik.snmp.ifInErrors) AS 'Receive Errors'
+    select: sum(kentik.snmp.ifInErrors)
     from: Metric
     where: "provider = 'kentik-router'"
     eventId: entityGuid
 
 transmitErrors:
-  title: Aggregate Transmit Errors (count)
+  title: Transmit Errors (count)
   unit: COUNT
   query:
-    select: sum(kentik.snmp.ifOutErrors) AS 'Transmit Errors'
+    select: sum(kentik.snmp.ifOutErrors)
     from: Metric
     where: "provider = 'kentik-router'"
     eventId: entityGuid

--- a/definitions/ext-router/summary_metrics.yml
+++ b/definitions/ext-router/summary_metrics.yml
@@ -1,0 +1,41 @@
+ipAddress:
+  title: Router IP Address
+  unit: STRING
+  tag:
+    key: src_addr
+
+cpuUtilization:
+  title: CPU Utilization (%)
+  unit: PERCENTAGE
+  query:
+    select: average(kentik.snmp.CPU) AS 'CPU Utilization'
+    from: Metric
+    where: "provider = 'router'"
+    eventId: entityGuid
+
+memoryUtilization:
+  title: Memory Utilization (%)
+  unit: PERCENTAGE
+  query:
+    select: average(kentik.snmp.MemoryUtilization) AS 'Memory Utilization'
+    from: Metric
+    where: "provider = 'router'"
+    eventId: entityGuid
+
+receiveErrors:
+  title: Aggregate Receive Errors (count)
+  unit: COUNT
+  query:
+    select: sum(kentik.snmp.ifInErrors) AS 'Receive Errors'
+    from: Metric
+    where: "provider = 'router'"
+    eventId: entityGuid
+
+transmitErrors:
+  title: Aggregate Transmit Errors (count)
+  unit: COUNT
+  query:
+    select: sum(kentik.snmp.ifOutErrors) AS 'Transmit Errors'
+    from: Metric
+    where: "provider = 'router'"
+    eventId: entityGuid


### PR DESCRIPTION
### Relevant information

adding `ROUTER` entity for the `EXT` domain. Original definition is based on network device metrics sent via Kentik technical partnership, but this definition is being kept ambiguous to allow for other technical partnerships to use the entity in the future.

`ROUTER` relates to any L3 device in the networking space that has the capability to route packets based on defined protocols. This entity can also be decorated with Flow telemetry (NetFlow/sFlow/jFlow/IPFIX/etc), among other things. 

### Checklist

* [X] I've read the guidelines and understand the acceptance criteria.
* [X] The value of the attribute marked as `identifier` will be unique and valid. 
* [X] I've confirmed that my entity type wasn't already defined. If it is I'm providing an
 explanation above.
