### PR TITLE
Add `aws.region` as golden tag

### DIFF
--- a/definitions/infra-awsalb/definition.yml
+++ b/definitions/infra-awsalb/definition.yml
@@ -2,6 +2,7 @@ domain: INFRA
 type: AWSALB
 goldenTags:
 - aws.awsRegion
+- aws.region
 - aws.state
 - aws.type
 - aws.ipAdressType

--- a/definitions/infra-awsalbtargetgroup/definition.yml
+++ b/definitions/infra-awsalbtargetgroup/definition.yml
@@ -2,6 +2,7 @@ domain: INFRA
 type: AWSALBTARGETGROUP
 goldenTags:
 - aws.awsRegion
+- aws.region
 - aws.matcher
 - aws.port
 - aws.protocol

--- a/definitions/infra-awsautoscalinggroup/definition.yml
+++ b/definitions/infra-awsautoscalinggroup/definition.yml
@@ -3,6 +3,7 @@ type: AWSAUTOSCALINGGROUP
 goldenTags:
 - aws.accountId
 - aws.awsRegion
+- aws.region
 - aws.availabilityZone
 compositeMetrics:
   goldenMetrics:

--- a/definitions/infra-awscloudfrontdistribution/definition.yml
+++ b/definitions/infra-awscloudfrontdistribution/definition.yml
@@ -3,6 +3,7 @@ type: AWSCLOUDFRONTDISTRIBUTION
 goldenTags:
 - aws.accountId
 - aws.awsRegion
+- aws.region
 - aws.availabilityZone
 compositeMetrics:
   goldenMetrics:

--- a/definitions/infra-awsdocdbcluster/definition.yml
+++ b/definitions/infra-awsdocdbcluster/definition.yml
@@ -4,6 +4,7 @@ goldenTags:
 - aws.accountId
 - aws.availabilityZone
 - aws.awsRegion
+- aws.region
 compositeMetrics:
   goldenMetrics:
   - golden_metrics.yml

--- a/definitions/infra-awsdocdbclusterbyrole/definition.yml
+++ b/definitions/infra-awsdocdbclusterbyrole/definition.yml
@@ -4,6 +4,7 @@ goldenTags:
 - aws.accountId
 - aws.availabilityZone
 - aws.awsRegion
+- aws.region
 compositeMetrics:
   goldenMetrics:
   - golden_metrics.yml

--- a/definitions/infra-awsdocdbinstance/definition.yml
+++ b/definitions/infra-awsdocdbinstance/definition.yml
@@ -4,6 +4,7 @@ goldenTags:
 - aws.accountId
 - aws.availabilityZone
 - aws.awsRegion
+- aws.region
 compositeMetrics:
   goldenMetrics:
   - golden_metrics.yml

--- a/definitions/infra-awsdynamodbglobalsecondaryindex/definition.yml
+++ b/definitions/infra-awsdynamodbglobalsecondaryindex/definition.yml
@@ -3,6 +3,7 @@ type: AWSDYNAMODBGLOBALSECONDARYINDEX
 goldenTags:
 - aws.accountId
 - aws.awsRegion
+- aws.region
 - aws.indexParentTable
 - aws.indexStatus
 compositeMetrics:

--- a/definitions/infra-awsdynamodbregion/definition.yml
+++ b/definitions/infra-awsdynamodbregion/definition.yml
@@ -3,6 +3,7 @@ type: AWSDYNAMODBREGION
 goldenTags:
 - aws.accountId
 - aws.awsRegion
+- aws.region
 compositeMetrics:
   goldenMetrics:
   - golden_metrics.yml

--- a/definitions/infra-awsdynamodbtable/definition.yml
+++ b/definitions/infra-awsdynamodbtable/definition.yml
@@ -3,6 +3,7 @@ type: AWSDYNAMODBTABLE
 goldenTags:
 - aws.accountId
 - aws.awsRegion
+- aws.region
 - aws.availabilityZone
 - aws.tableStatus
 compositeMetrics:

--- a/definitions/infra-awsecscluster/definition.yml
+++ b/definitions/infra-awsecscluster/definition.yml
@@ -2,6 +2,7 @@ domain: INFRA
 type: AWSECSCLUSTER
 goldenTags:
 - aws.awsRegion
+- aws.region
 - aws.clusterStatus
 - aws.accountId
 compositeMetrics:

--- a/definitions/infra-awsecsservice/definition.yml
+++ b/definitions/infra-awsecsservice/definition.yml
@@ -3,6 +3,7 @@ type: AWSECSSERVICE
 goldenTags:
 - aws.clusterName
 - aws.awsRegion
+- aws.region
 - aws.clusterName
 - aws.launchType
 - aws.serviceStatus

--- a/definitions/infra-awsefsfilesystem/definition.yml
+++ b/definitions/infra-awsefsfilesystem/definition.yml
@@ -3,6 +3,7 @@ type: AWSEFSFILESYSTEM
 goldenTags:
 - aws.accountId
 - aws.awsRegion
+- aws.region
 - aws.availabilityZone
 compositeMetrics:
   goldenMetrics:

--- a/definitions/infra-awselasticachememcachedcluster/definition.yml
+++ b/definitions/infra-awselasticachememcachedcluster/definition.yml
@@ -3,6 +3,7 @@ type: AWSELASTICACHEMEMCACHEDCLUSTER
 goldenTags:
 - aws.accountId
 - aws.awsRegion
+- aws.region
 - aws.customerAvailabilityZone
 - aws.cacheNodeType
 - aws.numCacheNodes

--- a/definitions/infra-awselasticachememcachednode/definition.yml
+++ b/definitions/infra-awselasticachememcachednode/definition.yml
@@ -3,6 +3,7 @@ type: AWSELASTICACHEMEMCACHEDNODE
 goldenTags:
 - aws.accountId
 - aws.awsRegion
+- aws.region
 - aws.customerAvailabilityZone
 - aws.cacheClusterId
 - aws.parameterGroupStatus

--- a/definitions/infra-awselasticacherediscluster/definition.yml
+++ b/definitions/infra-awselasticacherediscluster/definition.yml
@@ -3,6 +3,7 @@ type: AWSELASTICACHEREDISCLUSTER
 goldenTags:
 - aws.accountId
 - aws.awsRegion
+- aws.region
 - aws.customerAvailabilityZone
 - aws.cacheNodeType
 - aws.numCacheNodes

--- a/definitions/infra-awselasticacheredisnode/definition.yml
+++ b/definitions/infra-awselasticacheredisnode/definition.yml
@@ -3,6 +3,7 @@ type: AWSELASTICACHEREDISNODE
 goldenTags:
 - aws.accountId
 - aws.awsRegion
+- aws.region
 - aws.customerAvailabilityZone
 - aws.cacheClusterId
 - aws.parameterGroupStatus

--- a/definitions/infra-awselasticbeanstalkenvironment/definition.yml
+++ b/definitions/infra-awselasticbeanstalkenvironment/definition.yml
@@ -4,6 +4,7 @@ goldenTags:
 - aws.accountId
 - aws.availabilityZone
 - aws.awsRegion
+- aws.region
 - aws.applicationName
 - aws.environmentName
 compositeMetrics:

--- a/definitions/infra-awselasticbeanstalkinstance/definition.yml
+++ b/definitions/infra-awselasticbeanstalkinstance/definition.yml
@@ -4,6 +4,7 @@ goldenTags:
 - aws.accountId
 - aws.availabilityZone
 - aws.awsRegion
+- aws.region
 - aws.applicationName
 - aws.environmentName
 compositeMetrics:

--- a/definitions/infra-awselasticmapreducecluster/definition.yml
+++ b/definitions/infra-awselasticmapreducecluster/definition.yml
@@ -4,6 +4,7 @@ goldenTags:
 - aws.accountId
 - aws.availabilityZone
 - aws.awsRegion
+- aws.region
 compositeMetrics:
   goldenMetrics:
   - golden_metrics.yml

--- a/definitions/infra-awselasticsearchcluster/definition.yml
+++ b/definitions/infra-awselasticsearchcluster/definition.yml
@@ -3,6 +3,7 @@ type: AWSELASTICSEARCHCLUSTER
 goldenTags:
 - aws.accountId
 - aws.awsRegion
+- aws.region
 - aws.vpcId
 compositeMetrics:
   goldenMetrics:

--- a/definitions/infra-awselasticsearchnode/definition.yml
+++ b/definitions/infra-awselasticsearchnode/definition.yml
@@ -3,6 +3,7 @@ type: AWSELASTICSEARCHNODE
 goldenTags:
 - aws.accountId
 - aws.awsRegion
+- aws.region
 compositeMetrics:
   goldenMetrics:
   - golden_metrics.yml

--- a/definitions/infra-awselb/definition.yml
+++ b/definitions/infra-awselb/definition.yml
@@ -3,6 +3,7 @@ type: AWSELB
 goldenTags:
 - aws.accountId
 - aws.awsRegion
+- aws.region
 - aws.vpcId
 - aws.dnsName
 compositeMetrics:

--- a/definitions/infra-awskinesisanalyticsapplication/definition.yml
+++ b/definitions/infra-awskinesisanalyticsapplication/definition.yml
@@ -4,6 +4,7 @@ goldenTags:
 - aws.accountId
 - aws.availabilityZone
 - aws.awsRegion
+- aws.region
 compositeMetrics:
   goldenMetrics:
   - golden_metrics.yml

--- a/definitions/infra-awskinesisanalyticstask/definition.yml
+++ b/definitions/infra-awskinesisanalyticstask/definition.yml
@@ -4,6 +4,7 @@ goldenTags:
 - aws.accountId
 - aws.availabilityZone
 - aws.awsRegion
+- aws.region
 compositeMetrics:
   goldenMetrics:
   - golden_metrics.yml

--- a/definitions/infra-awskinesisdeliverystream/definition.yml
+++ b/definitions/infra-awskinesisdeliverystream/definition.yml
@@ -3,6 +3,7 @@ type: AWSKINESISDELIVERYSTREAM
 goldenTags:
 - aws.accountId
 - aws.awsRegion
+- aws.region
 - aws.availabilityZone
 - aws.status
 compositeMetrics:

--- a/definitions/infra-awskinesisstream/definition.yml
+++ b/definitions/infra-awskinesisstream/definition.yml
@@ -3,6 +3,7 @@ type: AWSKINESISSTREAM
 goldenTags:
 - aws.accountId
 - aws.awsRegion
+- aws.region
 - aws.availabilityZone
 compositeMetrics:
   goldenMetrics:

--- a/definitions/infra-awskinesisstreamshard/definition.yml
+++ b/definitions/infra-awskinesisstreamshard/definition.yml
@@ -3,6 +3,7 @@ type: AWSKINESISSTREAMSHARD
 goldenTags:
 - aws.accountId
 - aws.awsRegion
+- aws.region
 - aws.availabilityZone
 - aws.streamName
 compositeMetrics:

--- a/definitions/infra-awslambdafunction/definition.yml
+++ b/definitions/infra-awslambdafunction/definition.yml
@@ -2,6 +2,7 @@ domain: INFRA
 type: AWSLAMBDAFUNCTION
 goldenTags:
 - aws.awsRegion
+- aws.region
 - aws.accountId
 - aws.memorySize
 - aws.runtime

--- a/definitions/infra-awslambdaregion/definition.yml
+++ b/definitions/infra-awslambdaregion/definition.yml
@@ -2,6 +2,7 @@ domain: INFRA
 type: AWSLAMBDAREGION
 goldenTags:
 - aws.awsRegion
+- aws.region
 - aws.accountId
 - aws.concurrentExecutions
 - account

--- a/definitions/infra-awsnlb/definition.yml
+++ b/definitions/infra-awsnlb/definition.yml
@@ -2,6 +2,7 @@ domain: INFRA
 type: AWSNLB
 goldenTags:
 - aws.awsRegion
+- aws.region
 - aws.state
 - aws.type
 - aws.ipAdressType

--- a/definitions/infra-awsnlbtargetgroup/definition.yml
+++ b/definitions/infra-awsnlbtargetgroup/definition.yml
@@ -2,6 +2,7 @@ domain: INFRA
 type: AWSNLBTARGETGROUP
 goldenTags:
 - aws.awsRegion
+- aws.region
 - aws.port
 - aws.protocol
 - aws.matcher

--- a/definitions/infra-awsredshiftcluster/definition.yml
+++ b/definitions/infra-awsredshiftcluster/definition.yml
@@ -2,6 +2,7 @@ domain: INFRA
 type: AWSREDSHIFTCLUSTER
 goldenTags:
 - aws.awsRegion
+- aws.region
 - aws.clusterId
 - aws.accountId
 - aws.dbName

--- a/definitions/infra-awsredshiftnode/definition.yml
+++ b/definitions/infra-awsredshiftnode/definition.yml
@@ -2,6 +2,7 @@ domain: INFRA
 type: AWSREDSHIFTNODE
 goldenTags:
 - aws.awsRegion
+- aws.region
 - aws.clusterId
 - aws.accountId
 - aws.nodeId

--- a/definitions/infra-awss3bucket/definition.yml
+++ b/definitions/infra-awss3bucket/definition.yml
@@ -4,6 +4,7 @@ goldenTags:
 - aws.accountId
 - aws.availabilityZone
 - aws.awsRegion
+- aws.region
 compositeMetrics:
   goldenMetrics:
   - golden_metrics.yml

--- a/definitions/infra-awssnstopic/definition.yml
+++ b/definitions/infra-awssnstopic/definition.yml
@@ -4,6 +4,7 @@ goldenTags:
 - aws.accountId
 - aws.availabilityZone
 - aws.awsRegion
+- aws.region
 compositeMetrics:
   goldenMetrics:
   - golden_metrics.yml

--- a/definitions/infra-awssqsqueue/definition.yml
+++ b/definitions/infra-awssqsqueue/definition.yml
@@ -4,6 +4,7 @@ goldenTags:
 - aws.accountId
 - aws.availabilityZone
 - aws.awsRegion
+- aws.region
 compositeMetrics:
   goldenMetrics:
   - golden_metrics.yml

--- a/definitions/infra-host/definition.yml
+++ b/definitions/infra-host/definition.yml
@@ -5,6 +5,7 @@ goldenTags:
 - windowsPlatform
 - linuxDistribution
 - aws.awsRegion
+- aws.region
 - aws.availabilityZone
 - aws.accountId
 - azure.regionName


### PR DESCRIPTION
### Relevant information

We're in the process of renaming the `aws.awsRegion` tag to `aws.region`. During the migration we want to have both as golden tags, and once we finish the renaming for all the entities we will remove the `aws.awsRegion` one.

### Checklist

* [x] I've read the guidelines and understand the acceptance criteria.
* [ ] The value of the attribute marked as `identifier` will be unique and valid. 
* [ ] I've confirmed that my entity type wasn't already defined. If it is I'm providing an
 explanation above.
