### PR TITLE
Enforce maximum of 10 GM per definition file

### DIFF
--- a/validator/schemas/golden-metrics-schema-v1.json
+++ b/validator/schemas/golden-metrics-schema-v1.json
@@ -5,6 +5,7 @@
   "title": "Golden Metrics schema",
   "description": "The contents of each golden metric.",
   "minProperties": 1,
+  "maxProperties": 10,
   "examples": [
     {
       "memoryUsage": {


### PR DESCRIPTION
### Relevant information

Enforce maximum of 10 GM per definition file

For SM we 'recommend' a max of 10, so it cannot be enforced on the schema.

Btw, I checked and we are indeed validating correctly that we only receive 1 and only 1 condition here @srvaroa. 