### PR TITLE
Use the correct metric for K8s container mem usage

### DIFF
--- a/definitions/infra-container/golden_metrics.yml
+++ b/definitions/infra-container/golden_metrics.yml
@@ -10,7 +10,7 @@ cpuUtilization:
 memoryUsage:
   title: Memory usage (bytes)
   query:
-    select: max(docker.container.memoryUsageBytes) or max(k8s.container.memoryUtilization) AS 'Memory
+    select: max(docker.container.memoryUsageBytes) or max(k8s.container.memoryWorkingSetBytes) AS 'Memory
       used (bytes)'
 storageUsage:
   title: Storage usage (bytes)


### PR DESCRIPTION
### Relevant information

`memoryUtilization` is not the correct metric to monitor, we should be monitoring `memoryWorkingSetBytes` instead. This because `memoryUtilization` includes filesystem caching and memory that could be reclaimed, so it isn't a true indicator for OOM prevention.

### Checklist

* [ ] I've read the guidelines and understand the acceptance criteria.
* [ ] The value of the attribute marked as `identifier` will be unique and valid. 
* [ ] I've confirmed that my entity type wasn't already defined. If it is I'm providing an
 explanation above.
