### PR TITLE
Add definition and synthesis rule for KUBERNETES_POD

### DIFF
--- a/definitions/infra-kubernetespod/definition.yml
+++ b/definitions/infra-kubernetespod/definition.yml
@@ -1,0 +1,35 @@
+domain: INFRA
+type: KUBERNETES_POD
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true
+
+synthesis:
+  rules:
+  - identifier: entity.id
+    name: k8s.podName
+    encodeIdentifierInGUID: true
+    conditions:
+    - attribute: k8s.pod.isReady
+    tags:
+      k8s.status:
+      k8s.clusterName:
+      k8s.namespaceName:
+      k8s.podName:
+      k8s.nodeName:
+      k8s.pod.createdAt:
+      k8s.pod.startTime:
+      k8s.pod.isReady:
+      k8s.pod.isScheduled:
+      label.topology.kubernetes.io/region:
+      label.topology.kubernetes.io/zone:
+      label.eks.amazonaws.com/compute-type:
+      label.kubernetes.io/arch:
+      label.kubernetes.io/hostname:
+      label.kubernetes.io/os:
+  tags:
+    newrelic.integrationName:
+    newrelic.integrationVersion:
+    newrelic.agentVersion:
+    aws.region:
+    aws.ec2.instanceType:

--- a/definitions/infra-kubernetespod/definition.yml
+++ b/definitions/infra-kubernetespod/definition.yml
@@ -5,32 +5,30 @@ configuration:
   alertable: true
 
 synthesis:
-  rules:
-  - identifier: entity.id
-    name: k8s.podName
-    encodeIdentifierInGUID: true
-    conditions:
-    - attribute: k8s.pod.isReady
-    tags:
-      k8s.status:
-        multiValue: false
-      k8s.clusterName:
-      k8s.namespaceName:
-      k8s.podName:
-      k8s.nodeName:
-      k8s.pod.createdAt:
-      k8s.pod.startTime:
-      k8s.pod.isReady:
-        multiValue: false
-      k8s.pod.isScheduled:
-        multiValue: false
-      label.topology.kubernetes.io/region:
-      label.topology.kubernetes.io/zone:
-      label.eks.amazonaws.com/compute-type:
-      label.kubernetes.io/arch:
-      label.kubernetes.io/hostname:
-      label.kubernetes.io/os:
+  identifier: entity.id
+  name: k8s.podName
+  encodeIdentifierInGUID: true
+  conditions:
+  - attribute: k8s.pod.isReady
   tags:
+    k8s.status:
+      multiValue: false
+    k8s.clusterName:
+    k8s.namespaceName:
+    k8s.podName:
+    k8s.nodeName:
+    k8s.pod.createdAt:
+    k8s.pod.startTime:
+    k8s.pod.isReady:
+      multiValue: false
+    k8s.pod.isScheduled:
+      multiValue: false
+    label.topology.kubernetes.io/region:
+    label.topology.kubernetes.io/zone:
+    label.eks.amazonaws.com/compute-type:
+    label.kubernetes.io/arch:
+    label.kubernetes.io/hostname:
+    label.kubernetes.io/os:
     newrelic.integrationName:
     newrelic.integrationVersion:
         multiValue: false

--- a/definitions/infra-kubernetespod/definition.yml
+++ b/definitions/infra-kubernetespod/definition.yml
@@ -13,6 +13,7 @@ synthesis:
     - attribute: k8s.pod.isReady
     tags:
       k8s.status:
+        multiValue: false
       k8s.clusterName:
       k8s.namespaceName:
       k8s.podName:
@@ -20,7 +21,9 @@ synthesis:
       k8s.pod.createdAt:
       k8s.pod.startTime:
       k8s.pod.isReady:
+        multiValue: false
       k8s.pod.isScheduled:
+        multiValue: false
       label.topology.kubernetes.io/region:
       label.topology.kubernetes.io/zone:
       label.eks.amazonaws.com/compute-type:
@@ -30,6 +33,8 @@ synthesis:
   tags:
     newrelic.integrationName:
     newrelic.integrationVersion:
+        multiValue: false
     newrelic.agentVersion:
+        multiValue: false
     aws.region:
     aws.ec2.instanceType:


### PR DESCRIPTION
### Relevant information

This adds support for indexing Kubernetes Pods as entities. 

### Checklist

* [x] I've read the guidelines and understand the acceptance criteria.
* [x] The value of the attribute marked as `identifier` will be unique and valid. 
* [x] I've confirmed that my entity type wasn't already defined. If it is I'm providing an
 explanation above.
