### PR TITLE
Fix encodeIdentifierInGUID for Kubernetes pods and containers

### DIFF
--- a/definitions/infra-container/definition.yml
+++ b/definitions/infra-container/definition.yml
@@ -5,7 +5,7 @@ synthesis:
   rules:
   - identifier: entity.id
     name: docker.name
-    encodeIdentifierInGUID: true
+    encodeIdentifierInGUID: false
     conditions:
     - attribute: docker.containerId
     tags:

--- a/definitions/infra-kubernetespod/definition.yml
+++ b/definitions/infra-kubernetespod/definition.yml
@@ -7,7 +7,7 @@ configuration:
 synthesis:
   identifier: entity.id
   name: k8s.podName
-  encodeIdentifierInGUID: true
+  encodeIdentifierInGUID: false
   conditions:
   - attribute: k8s.pod.isReady
   tags:


### PR DESCRIPTION
### Relevant information

Fix the `encodeIdentifierInGUID` setting for Kubernetes pods and containers.

### Checklist

* [x] I've read the guidelines and understand the acceptance criteria.
* [x] The value of the attribute marked as `identifier` will be unique and valid. 
* [x] I've confirmed that my entity type wasn't already defined. If it is I'm providing an
 explanation above.
