### PR TITLE
Fix: add provider filter for RDS

### DIFF
--- a/definitions/infra-awsrdsdbcluster/summary_metrics.yml
+++ b/definitions/infra-awsrdsdbcluster/summary_metrics.yml
@@ -8,6 +8,7 @@ readIops:
     eventId: entityGuid
     select: average(`provider.volumeReadIops.Average`)
     from: DatastoreSample
+    where: provider='RdsDbCluster'
   unit: COUNT
   title: Read IOPS
 writeIops:
@@ -15,5 +16,6 @@ writeIops:
     eventId: entityGuid
     select: average(`provider.volumeWriteIops.Average`)
     from: DatastoreSample
+    where: provider='RdsDbCluster'
   unit: COUNT
   title: Write IOPS

--- a/definitions/infra-awsrdsdbinstance/summary_metrics.yml
+++ b/definitions/infra-awsrdsdbinstance/summary_metrics.yml
@@ -13,6 +13,7 @@ throughput:
     eventId: entityGuid
     select: average(`provider.readThroughput.Average`) + average(`provider.writeThroughput.Average`)
     from: DatastoreSample
+    where: provider='RdsDbInstance'
   unit: BYTES
   title: Throughput
 freeStorage:
@@ -20,6 +21,7 @@ freeStorage:
     eventId: entityGuid
     select: min(`provider.freeStorageSpaceBytes.Minimum`)
     from: DatastoreSample
+    where: provider='RdsDbInstance'
   unit: BYTES
   title: Free storage
 cpuUtilization:
@@ -27,5 +29,6 @@ cpuUtilization:
     eventId: entityGuid
     select: average(`provider.cpuUtilization.Average`)
     from: DatastoreSample
+    where: provider='RdsDbInstance'
   unit: PERCENTAGE
   title: CPU utilization


### PR DESCRIPTION
### Relevant information

Added the provider filter to RDS entities. We're seeing shimming errors and we believe it might be because of this missing filter.

### Checklist

* [ ] I've read the guidelines and understand the acceptance criteria.
* [ ] The value of the attribute marked as `identifier` will be unique and valid. 
* [ ] I've confirmed that my entity type wasn't already defined. If it is I'm providing an
 explanation above.
