### PR TITLE
Remove vsphere metrics that return a string value

### DIFF
--- a/definitions/infra-vspherecluster/summary_metrics.yml
+++ b/definitions/infra-vspherecluster/summary_metrics.yml
@@ -12,10 +12,3 @@ hostsCount:
     from: VSphereClusterSample
   unit: COUNT
   title: Hosts count
-overallStatus:
-  query:
-    eventId: entityGuid
-    select: latest(`overallStatus`)
-    from: VSphereClusterSample
-  unit: COUNT
-  title: Overall status

--- a/definitions/infra-vspheredatacenter/summary_metrics.yml
+++ b/definitions/infra-vspheredatacenter/summary_metrics.yml
@@ -12,10 +12,3 @@ memUsage:
     from: VSphereDatacenterSample
   unit: BYTES
   title: Memory usage
-overallStatus:
-  query:
-    eventId: entityGuid
-    select: latest(`overallStatus`)
-    from: VSphereDatacenterSample
-  unit: COUNT
-  title: Overall status

--- a/definitions/infra-vspheredatastore/summary_metrics.yml
+++ b/definitions/infra-vspheredatastore/summary_metrics.yml
@@ -12,10 +12,3 @@ vmCount:
     from: VSphereDatastoreSample
   unit: COUNT
   title: Virtual Machines count
-accessible:
-  query:
-    eventId: entityGuid
-    select: latest(`accessible`)
-    from: VSphereDatastoreSample
-  unit: COUNT
-  title: Accessible

--- a/definitions/infra-vspherehost/golden_metrics.yml
+++ b/definitions/infra-vspherehost/golden_metrics.yml
@@ -19,10 +19,3 @@ diskUsageMib:
     from: VSphereHostSample
     eventId: entityGuid
     eventName: entityName
-connectionState:
-  title: Connection State of the Host
-  query:
-    eventId: entityGuid
-    select: latest(`connectionState`)
-    from: VSphereHostSample
-    eventName: entityName

--- a/definitions/infra-vspherehost/summary_metrics.yml
+++ b/definitions/infra-vspherehost/summary_metrics.yml
@@ -19,10 +19,3 @@ vmCount:
     from: VSphereHostSample
   unit: COUNT
   title: Virtual Machines count
-connectionState:
-  query:
-    eventId: entityGuid
-    select: latest(`connectionState`)
-    from: VSphereHostSample
-  unit: COUNT
-  title: Connection State

--- a/definitions/infra-vsphereresourcepool/summary_metrics.yml
+++ b/definitions/infra-vsphereresourcepool/summary_metrics.yml
@@ -12,10 +12,3 @@ memSwapped:
     from: VSphereResourcePoolSample
   unit: BYTES
   title: Memory swapped
-overallStatus:
-  query:
-    eventId: entityGuid
-    select: latest(`overallStatus`)
-    from: VSphereResourcePoolSample
-  unit: COUNT
-  title: Overall status

--- a/definitions/infra-vspherevm/summary_metrics.yml
+++ b/definitions/infra-vspherevm/summary_metrics.yml
@@ -19,17 +19,3 @@ cpuAllocationlimit:
     from: VSphereVmSample
   unit: HERTZ
   title: CPU Allocation Limit
-powerState:
-  query:
-    eventId: entityGuid
-    select: latest(`powerState`)
-    from: VSphereVmSample
-  unit: COUNT
-  title: Power State
-connectionState:
-  query:
-    eventId: entityGuid
-    select: latest(`connectionState`)
-    from: VSphereVmSample
-  unit: COUNT
-  title: Connection State


### PR DESCRIPTION
### Relevant information

We don't currently support metrics that return strings.
So remove them for now

### Checklist

* [ ] I've read the guidelines and understand the acceptance criteria.
* [ ] The value of the attribute marked as `identifier` will be unique and valid. 
* [ ] I've confirmed that my entity type wasn't already defined. If it is I'm providing an
 explanation above.
