### PR TITLE
Remove synthesis from EXT-HOST

### DIFF
--- a/definitions/ext-host/definition.yml
+++ b/definitions/ext-host/definition.yml
@@ -1,11 +1,5 @@
 domain: EXT
 type: HOST
-synthesis:
-  identifier: host
-  name: host
-  encodeIdentifierInGUID: true
-  conditions:
-  - attribute: host
 configuration:
   entityExpirationTime: DAILY
   alertable: false


### PR DESCRIPTION
This is a legacy type that was adde in the original version of synthesis
but is proving problematic as the matching rule is too broad (anything
with a `host` attribute will match).  We're disabling this for now,
although the type is respected.

Signed-off-by: Galo Navarro <gnavarro@newrelic.com>

### Relevant information

Describe what you have done and any details that you think are relevant or that you might want to discuss with us. 

### Checklist

* [x] I've read the guidelines and understand the acceptance criteria.
* [x] The value of the attribute marked as `identifier` will be unique and valid. 
* [x] I've confirmed that my entity type wasn't already defined. If it is I'm providing an
 explanation above.
