### PR TITLE
Remove tags that are considered metrics in Kubernetes entities

### DIFF
--- a/definitions/infra-kubernetes_deployment/definition.yml
+++ b/definitions/infra-kubernetes_deployment/definition.yml
@@ -16,7 +16,6 @@ synthesis:
     k8s.clusterName:
     k8s.namespaceName:
     k8s.deploymentName:
-    k8s.deployment.createdAt:
     label.topology.kubernetes.io/region:
     label.topology.kubernetes.io/zone:
     label.eks.amazonaws.com/compute-type:

--- a/definitions/infra-kubernetes_pod/definition.yml
+++ b/definitions/infra-kubernetes_pod/definition.yml
@@ -20,12 +20,6 @@ synthesis:
     k8s.deploymentName:
     k8s.createdBy:
     k8s.createdKind:
-    k8s.pod.createdAt:
-    k8s.pod.startTime:
-    k8s.pod.isReady:
-      multiValue: false
-    k8s.pod.isScheduled:
-      multiValue: false
     label.topology.kubernetes.io/region:
     label.topology.kubernetes.io/zone:
     label.eks.amazonaws.com/compute-type:


### PR DESCRIPTION
### Relevant information

These tags are considered metrics in the system, so they cannot be tags otherwise things go bad.

### Checklist

* [x] I've read the guidelines and understand the acceptance criteria.

