### PR TITLE
Remove GM queries provider validation and add to query instead

### DIFF
--- a/validator/schemas/golden-metrics-schema-v1.json
+++ b/validator/schemas/golden-metrics-schema-v1.json
@@ -54,9 +54,6 @@
       "queries": {
         "$id": "#/properties/queries",
         "type": "object",
-        "propertyNames": {
-          "pattern": "^[a-zA-Z0-9_]{1,100}$"
-        },
         "additionalProperties": {
           "$ref": "#/definitions/query"
         }
@@ -68,6 +65,9 @@
       "$id": "#/definitions/query",
       "type": "object",
       "title": "The query schema",
+      "propertyNames": {
+        "pattern": "^[a-zA-Z0-9_]{1,100}$"
+      },
       "description": "Information about the query to get the golden metric.",
       "examples": [
         {


### PR DESCRIPTION
### Relevant information

For GMs we were wrongly validating the name of the 'provider' in `queries` against our GM key regex, but the provider doesn't need to have the same restrictions (i.e. no dashes). 

This will fix a [PR that is failing](https://github.com/newrelic-experimental/entity-synthesis-definitions/pull/145) because of the wrong validation. 

