### PR TITLE
Improve and fix the summary for k8s pods

### DIFF
--- a/definitions/infra-kubernetes_pod/summary_metrics.yml
+++ b/definitions/infra-kubernetes_pod/summary_metrics.yml
@@ -17,12 +17,11 @@ createdBy:
   title: Creator name
   unit: STRING
   tag:
-    key: createdBy
+    key: k8s.createdBy
 createdKind:
   title: Creator kind
   unit: STRING
   tag:
-    key: createdKind
 txNetwork:
   query:
     eventId: entityGuid
@@ -37,6 +36,7 @@ rxNetwork:
     from: K8sPodSample
   unit: BYTES_PER_SECOND
   title: Network Rx
+    key: k8s.createdKind
 errorsNetwork:
   query:
     eventId: entityGuid

--- a/definitions/infra-kubernetes_pod/summary_metrics.yml
+++ b/definitions/infra-kubernetes_pod/summary_metrics.yml
@@ -22,20 +22,6 @@ createdKind:
   title: Creator kind
   unit: STRING
   tag:
-txNetwork:
-  query:
-    eventId: entityGuid
-    select: average(net.txBytesPerSecond)
-    from: K8sPodSample
-  unit: BYTES_PER_SECOND
-  title: Network Tx
-rxNetwork:
-  query:
-    eventId: entityGuid
-    select: average(net.rxBytesPerSecond)
-    from: K8sPodSample
-  unit: BYTES_PER_SECOND
-  title: Network Rx
     key: k8s.createdKind
 errorsNetwork:
   query:

--- a/definitions/infra-kubernetes_pod/summary_metrics.yml
+++ b/definitions/infra-kubernetes_pod/summary_metrics.yml
@@ -13,6 +13,11 @@ namespaceName:
   unit: STRING
   tag:
     key: k8s.namespaceName
+status:
+  title: Status
+  unit: STRING
+  tag:
+    key: k8s.status
 createdBy:
   title: Creator name
   unit: STRING


### PR DESCRIPTION
### Relevant information

1. The pod's summary is getting slightly crowded. We will stop showing network tx and rx metrics there. Network errors stay. 
2. Added the pod's status to the summary metrics
3. Fixed the pod creator name and kind in the pod summary metrics

### Checklist

* [x] I've read the guidelines and understand the acceptance criteria.
* [x] The value of the attribute marked as `identifier` will be unique and valid. 
* [x] I've confirmed that my entity type wasn't already defined. If it is I'm providing an
 explanation above.
