### PR TITLE
Add multiple synth rules for ext-service

### DIFF
--- a/definitions/ext-service/definition.yml
+++ b/definitions/ext-service/definition.yml
@@ -1,11 +1,25 @@
 domain: EXT
 type: SERVICE
 synthesis:
-  identifier: service.name
-  name: service.name
-  encodeIdentifierInGUID: true
-  conditions:
-  - attribute: service.name
+  rules:
+    # telemetry with service.name attribute
+    - identifier: service.name
+      name: service.name
+      encodeIdentifierInGUID: true
+      conditions:
+        - attribute: service.name
+    # telemetry with service_name attribute
+    - identifier: service_name
+      name: service_name
+      encodeIdentifierInGUID: true
+      conditions:
+        - attribute: service_name
+    # telemetry with serviceName attribute
+    - identifier: serviceName
+      name: serviceName
+      encodeIdentifierInGUID: true
+      conditions:
+        - attribute: serviceName
 configuration:
   entityExpirationTime: EIGHT_DAYS
   alertable: true


### PR DESCRIPTION
### Relevant information

We want to synthesize ext-service entities from telemetry that contains any of the following attributes:

- service.name
- service_name
- serviceName