### PR TITLE
Add summary metrics, golden metrics and tags for K8s daemonset

### DIFF
--- a/definitions/infra-kubernetes_daemonset/definition.yml
+++ b/definitions/infra-kubernetes_daemonset/definition.yml
@@ -3,7 +3,15 @@ type: KUBERNETES_DAEMONSET
 configuration:
   entityExpirationTime: DAILY
   alertable: true
-
+goldenTags:
+  - k8s.daemonsetName
+  - k8s.clusterName
+  - k8s.namespaceName
+compositeMetrics:
+  goldenMetrics:
+    - golden_metrics.yml
+  summaryMetrics:
+    - summary_metrics.yml
 synthesis:
   identifier: entity.id
   name: k8s.daemonsetName

--- a/definitions/infra-kubernetes_daemonset/definition.yml
+++ b/definitions/infra-kubernetes_daemonset/definition.yml
@@ -11,8 +11,6 @@ synthesis:
   conditions:
   - attribute: k8s.daemonset.podsAvailable
   tags:
-    k8s.status:
-      multiValue: false
     k8s.clusterName:
     k8s.namespaceName:
     k8s.daemonsetName:

--- a/definitions/infra-kubernetes_daemonset/golden_metrics.yml
+++ b/definitions/infra-kubernetes_daemonset/golden_metrics.yml
@@ -1,0 +1,21 @@
+podsDesired:
+  title: Pods desired over time
+  query:
+    select: latest(podsDesired)
+    from: K8sDaemonsetSample
+    eventId: entityGuid
+    eventName: entityName
+podsReady:
+  title: Pods ready over time
+  query:
+    select: latest(podsReady)
+    from: K8sDaemonsetSample
+    eventId: entityGuid
+    eventName: entityName
+podsMissing:
+  title: Pods missing over time
+  query:
+    select: latest(podsMissing)
+    from: K8sDaemonsetSample
+    eventId: entityGuid
+    eventName: entityName

--- a/definitions/infra-kubernetes_daemonset/summary_metrics.yml
+++ b/definitions/infra-kubernetes_daemonset/summary_metrics.yml
@@ -1,0 +1,31 @@
+clusterName:
+  title: Cluster name
+  unit: STRING
+  tag:
+    key: k8s.clusterName
+namespaceName:
+  title: Namespace name
+  unit: STRING
+  tag:
+    key: k8s.namespaceName
+podsDesired:
+  query:
+    eventId: entityGuid
+    select: latest(podsDesired)
+    from: K8sDaemonsetSample
+  unit: COUNT
+  title: Pods desired
+podsReady:
+  query:
+    eventId: entityGuid
+    select: latest(podsReady)
+    from: K8sDaemonsetSample
+  unit: COUNT
+  title: Pods ready
+podsMissing:
+  query:
+    eventId: entityGuid
+    select: latest(podsMissing)
+    from: K8sDaemonsetSample
+  unit: COUNT
+  title: Pods missing


### PR DESCRIPTION
### Relevant information

Add summary metrics, golden metrics and tags for K8s daemonset entity.
Also remove the `k8s.status` from its synthesis definition since it's not a tag that is available for this entity.

### Checklist

* [ ] I've read the guidelines and understand the acceptance criteria.
* [ ] The value of the attribute marked as `identifier` will be unique and valid. 
* [ ] I've confirmed that my entity type wasn't already defined. If it is I'm providing an
 explanation above.
