### PR TITLE
Add dashboard for unix host

### DIFF
--- a/definitions/ext-unix_host/dashboard.json
+++ b/definitions/ext-unix_host/dashboard.json
@@ -1,0 +1,47 @@
+{
+  "title": "Unix Host status",
+  "icon": "line-chart",
+  "grid_column_count": 12,
+  "filter": null,
+  "widgets": [
+    {
+      "title": "CPU Utilization (%)",
+      "nrql": "SELECT 100-latest(cpu.idle) FROM `unixMonitor:Stats`",
+      "process_as": "billboard",
+      "width": 4,
+      "height": 3,
+      "row": 1,
+      "column": 1,
+      "event_types": null,
+      "facet": null,
+      "customizations": null,
+      "notes": null
+    },
+    {
+      "title": "Memory Utilization (%)",
+      "nrql": "SELECT (latest(memory.total) - latest(memory.free))/latest(memory.total) * 100 FROM `unixMonitor:Stats`",
+      "process_as": "billboard",
+      "width": 4,
+      "height": 3,
+      "row": 1,
+      "column": 5,
+      "event_types": null,
+      "facet": null,
+      "customizations": null,
+      "notes": null
+    },
+    {
+      "title": "Disk Utilization (%)",
+      "nrql": "SELECT max(percentUsed) FROM `unixMonitor:Disk` FACET mountedOn",
+      "process_as": "billboard",
+      "width": 4,
+      "height": 3,
+      "row": 1,
+      "column": 9,
+      "event_types": null,
+      "facet": null,
+      "customizations": null,
+      "notes": null
+    }
+  ]
+}

--- a/definitions/ext-unix_host/definition.yml
+++ b/definitions/ext-unix_host/definition.yml
@@ -1,11 +1,16 @@
 domain: EXT
 type: UNIX_HOST
+
 synthesis:
   name: hostname
   identifier: hostname
   conditions:
   - attribute: eventType
     prefix: "unixMonitor:"
+
+dashboardTemplates:
+  newRelic:
+    template: dashboard.json
 
 compositeMetrics:
   goldenMetrics:


### PR DESCRIPTION
### Relevant information

Add a dashboard for EXT-UNIX_HOST based on the GMs defined for the entity. In the old format since we need to have this working today. 
