### PR TITLE
Fix misconfigured EXT summary metrics

### DIFF
--- a/definitions/ext-network_synth/summary_metrics.yml
+++ b/definitions/ext-network_synth/summary_metrics.yml
@@ -5,7 +5,7 @@ testLocations:
     select: uniqueCount(agent_name)
     from: Metric
     where: "provider = 'kentik-network-synthetic'"
-    eventId: entityGuid
+    eventId: entity.guid
 
 averageLatency:
   title: Average Latency (s)
@@ -14,7 +14,7 @@ averageLatency:
     select: average(kentik.synth.avg_rtt)/1000000
     from: Metric
     where: "provider = 'kentik-network-synthetic'"
-    eventId: entityGuid
+    eventId: entity.guid
 
 averageJitter:
   title: Average Jitter (s)
@@ -23,7 +23,7 @@ averageJitter:
     select: average(kentik.synth.jit_rtt)/1000000
     from: Metric
     where: "provider = 'kentik-network-synthetic'"
-    eventId: entityGuid
+    eventId: entity.guid
 
 packetLoss:
   title: Packet Loss (%)
@@ -32,4 +32,4 @@ packetLoss:
     select: latest(kentik.synth.lost_pct)
     from: Metric
     where: "provider = 'kentik-network-synthetic'"
-    eventId: entityGuid
+    eventId: entity.guid

--- a/definitions/ext-router/summary_metrics.yml
+++ b/definitions/ext-router/summary_metrics.yml
@@ -11,7 +11,7 @@ cpuUtilization:
     select: average(kentik.snmp.CPU)
     from: Metric
     where: "provider = 'kentik-router'"
-    eventId: entityGuid
+    eventId: entity.guid
 
 memoryUtilization:
   title: Memory Utilization (%)
@@ -20,7 +20,7 @@ memoryUtilization:
     select: average(kentik.snmp.MemoryUtilization)
     from: Metric
     where: "provider = 'kentik-router'"
-    eventId: entityGuid
+    eventId: entity.guid
 
 receiveErrors:
   title: Receive Errors (count)
@@ -29,7 +29,7 @@ receiveErrors:
     select: sum(kentik.snmp.ifInErrors)
     from: Metric
     where: "provider = 'kentik-router'"
-    eventId: entityGuid
+    eventId: entity.guid
 
 transmitErrors:
   title: Transmit Errors (count)
@@ -38,4 +38,4 @@ transmitErrors:
     select: sum(kentik.snmp.ifOutErrors)
     from: Metric
     where: "provider = 'kentik-router'"
-    eventId: entityGuid
+    eventId: entity.guid

--- a/definitions/ext-switch/summary_metrics.yml
+++ b/definitions/ext-switch/summary_metrics.yml
@@ -11,7 +11,7 @@ cpuUtilization:
     select: average(kentik.snmp.CPU)
     from: Metric
     where: "provider = 'kentik-switch'"
-    eventId: entityGuid
+    eventId: entity.guid
 
 memoryUtilization:
   title: Memory Utilization (%)
@@ -20,7 +20,7 @@ memoryUtilization:
     select: average(kentik.snmp.MemoryUtilization)
     from: Metric
     where: "provider = 'kentik-switch'"
-    eventId: entityGuid
+    eventId: entity.guid
 
 receiveErrors:
   title: Receive Errors (count)
@@ -29,7 +29,7 @@ receiveErrors:
     select: sum(kentik.snmp.ifInErrors)
     from: Metric
     where: "provider = 'kentik-switch'"
-    eventId: entityGuid
+    eventId: entity.guid
 
 transmitErrors:
   title: Transmit Errors (count)
@@ -38,4 +38,4 @@ transmitErrors:
     select: sum(kentik.snmp.ifOutErrors)
     from: Metric
     where: "provider = 'kentik-switch'"
-    eventId: entityGuid
+    eventId: entity.guid


### PR DESCRIPTION
### Relevant information

The SM for some EXT entity types were null despite the data being available on the telemetry. Looking into it with @naxhh we saw that the eventId seemed to be wrong and changing it from `entityGuid` to `entity.guid` fixed the queries. 

I saw that some infra entities are also using `entityGuid` but it seems like those SM are working, we might want to take a better look at them, because if we could change them to `entity.guid` we could add a validation to prevent people from using `entityGuid` (there are also many golden metrics using `entityGuid`).