### PR TITLE
Added golden metrics for multiple open instrumentation providers (ext-service)

### DIFF
--- a/definitions/ext-service/definition.yml
+++ b/definitions/ext-service/definition.yml
@@ -2,7 +2,28 @@ domain: EXT
 type: SERVICE
 synthesis:
   rules:
-    # opentelemetry provider
+    # telemetry with service.name attribute
+    - identifier: service.name
+      name: service.name
+      encodeIdentifierInGUID: true
+      conditions:
+        - attribute: service.name
+
+    # telemetry with service_name attribute
+    - identifier: service_name
+      name: service_name
+      encodeIdentifierInGUID: true
+      conditions:
+        - attribute: service_name
+
+    # telemetry with serviceName attribute
+    - identifier: serviceName
+      name: serviceName
+      encodeIdentifierInGUID: true
+      conditions:
+        - attribute: serviceName
+
+    # telemetry from opentelemetry provider
     - identifier: service.name
       name: service.name
       encodeIdentifierInGUID: true
@@ -16,21 +37,7 @@ synthesis:
           entityTagName: language
         telemetry.sdk.version:
 
-    # any telemetry with service_name attribute
-    - identifier: service_name
-      name: service_name
-      encodeIdentifierInGUID: true
-      conditions:
-        - attribute: service_name
-
-    # any telemetry with serviceName attribute
-    - identifier: serviceName
-      name: serviceName
-      encodeIdentifierInGUID: true
-      conditions:
-        - attribute: serviceName
-
-    # kamon-agent provider
+    # telemetry from kamon-agent provider
     - identifier: service.name
       name: service.name
       encodeIdentifierInGUID: true
@@ -40,7 +47,7 @@ synthesis:
       tags:
         instrumentation.provider:
 
-    # micrometer provider
+    # telemetry from micrometer provider
     - identifier: service.name
       name: service.name
       encodeIdentifierInGUID: true

--- a/definitions/ext-service/definition.yml
+++ b/definitions/ext-service/definition.yml
@@ -2,24 +2,58 @@ domain: EXT
 type: SERVICE
 synthesis:
   rules:
-    # telemetry with service.name attribute
+    # opentelemetry provider
     - identifier: service.name
       name: service.name
       encodeIdentifierInGUID: true
       conditions:
-        - attribute: service.name
-    # telemetry with service_name attribute
+        - attribute: telemetry.sdk.name
+          value: opentelemetry
+      tags:
+        telemetry.sdk.name:
+          entityTagName: instrumentation.provider
+        telemetry.sdk.language:
+          entityTagName: language
+        telemetry.sdk.version:
+
+    # any telemetry with service_name attribute
     - identifier: service_name
       name: service_name
       encodeIdentifierInGUID: true
       conditions:
         - attribute: service_name
-    # telemetry with serviceName attribute
+
+    # any telemetry with serviceName attribute
     - identifier: serviceName
       name: serviceName
       encodeIdentifierInGUID: true
       conditions:
         - attribute: serviceName
+
+    # kamon-agent provider
+    - identifier: service.name
+      name: service.name
+      encodeIdentifierInGUID: true
+      conditions:
+        - attribute: instrumentation.provider
+          value: kamon-agent
+      tags:
+        instrumentation.provider:
+
+    # micrometer provider
+    - identifier: service.name
+      name: service.name
+      encodeIdentifierInGUID: true
+      conditions:
+        - attribute: instrumentation.provider
+          value: micrometer
+      tags:
+        instrumentation.provider:
+
+compositeMetrics:
+  goldenMetrics:
+    - golden_metrics.yml
+
 configuration:
   entityExpirationTime: EIGHT_DAYS
   alertable: true

--- a/definitions/ext-service/golden_metrics.yml
+++ b/definitions/ext-service/golden_metrics.yml
@@ -1,0 +1,38 @@
+throughput:
+  title: Throughput
+  queries:
+    opentelemetry:
+      select: count(*)
+      from: Span
+      where: span.kind LIKE 'server' OR span.kind LIKE 'consumer' OR kind LIKE 'server' OR kind LIKE 'consumer'
+    kamon-agent:
+      select: sum(http.server.requests)
+      from: Metric
+    micrometer:
+      select: sum(http.server.requests)
+      from: Metric
+errorRate:
+  title: Error rate
+  queries:
+    opentelemetry:
+      select: filter(count(*), where error.message IS NOT NULL) / count(*)
+      from: Span
+    kamon-agent:
+      select: filter(sum(http.server.requests), where http.status_code = '5xx') / sum(http.server.requests)
+      from: Metric
+    micrometer:
+      select: filter(sum(http.server.requests), where exception IS NOT NULL and exception != 'None') / sum(http.server.requests)
+      from: Metric
+responseTimeMs:
+  title: Response time (ms)
+  queries:
+    opentelemetry:
+      select: average(duration.ms)
+      from: Span
+      where: span.kind LIKE 'server' OR span.kind LIKE 'consumer' OR kind LIKE 'server' OR kind LIKE 'consumer'
+    kamon-agent:
+      select: average(http.server.requests)
+      from: Metric
+    micrometer:
+      select: average(http.server.requests)
+      from: Metric


### PR DESCRIPTION
### Relevant information

Added golden metrics for multiple open instrumentation providers under ext-service such as opentelemetry, kamon-agent and micrometer.

### Checklist

* [x] I've read the guidelines and understand the acceptance criteria.
* [x] The value of the attribute marked as `identifier` will be unique and valid. 
* [x] I've confirmed that my entity type wasn't already defined. If it is I'm providing an
 explanation above.
