### PR TITLE
Migrate host summary metrics to Metric event type

### DIFF
--- a/definitions/infra-host/summary_metrics.yml
+++ b/definitions/infra-host/summary_metrics.yml
@@ -7,33 +7,33 @@ cpuUtilizationPercentHost:
   title: Host CPU Utilization Percent
   unit: PERCENTAGE
   query:
-    from: SystemSample
-    select: average(cpuPercent)
-    eventId: entityGuid
+    from: Metric
+    select: average(host.cpuPercent)
+    eventId: entity.guid
   hidden: true
 cpuUtilizationPercentEc2:
   title: EC2 CPU Utilization Percent
   unit: PERCENTAGE
   query:
-    from: ComputeSample
-    select: average(provider.cpuUtilization.Average)
-    eventId: entityGuid
+    from: Metric
+    select: average(aws.ec2.CPUUtilization)
+    eventId: entity.guid
   hidden: true
 cpuUtilizationPercentAzure:
   title: Azure CPU Utilization Percent
   unit: PERCENTAGE
   query:
-    from: AzureVirtualMachineSample
-    select: average(cpuUsagePercent.Average)
-    eventId: entityGuid
+    from: Metric
+    select: average(azure.compute.virtualmachines.PercentageCPU)
+    eventId: entity.guid
   hidden: true
 cpuUtilizationPercentGcp:
   title: GCP CPU Utilization Percent
   unit: PERCENTAGE
   query:
-    from: GcpVirtualMachineSample
-    select: average(instance.cpu.Utilization)
-    eventId: entityGuid
+    from: Metric
+    select: average(gcp.compute.instance.cpu.utilization)
+    eventId: entity.guid
   hidden: true
 cpuUtilizationPercent:
   title: CPU Utilization Percent
@@ -43,31 +43,31 @@ memoryUsedPercent:
   title: Memory Used Percent
   unit: PERCENTAGE
   query:
-    from: SystemSample
-    select: average(memoryUsedPercent)
-    eventId: entityGuid
+    from: Metric
+    select: average(host.memoryUsedPercent)
+    eventId: entity.guid
 diskUsedPercent:
   title: Disk Used Percent
   unit: PERCENTAGE
   query:
-    from: SystemSample
-    select: average(diskUsedPercent)
-    eventId: entityGuid
+    from: Metric
+    select: average(host.diskUsedPercent)
+    eventId: entity.guid
 networkInHost:
   title: Network In Host
   unit: BYTES_PER_SECOND
   query:
-    from: NetworkSample
-    select: average(receiveBytesPerSecond)
-    eventId: entityGuid
+    from: Metric
+    select: average(host.net.receiveBytesPerSecond)
+    eventId: entity.guid
   hidden: true
 networkOutHost:
   title: Network Out Host
   unit: BYTES_PER_SECOND
   query:
-    from: NetworkSample
-    select: average(transmitBytesPerSecond)
-    eventId: entityGuid
+    from: Metric
+    select: average(host.net.transmitBytesPerSecond)
+    eventId: entity.guid
   hidden: true
 networkTrafficHost:
   title: Network Traffic Host
@@ -78,17 +78,17 @@ networkInEc2:
   title: Network In EC2
   unit: BYTES_PER_SECOND
   query:
-    from: ComputeSample
-    select: average(provider.networkInBytes.Average)
-    eventId: entityGuid
+    from: Metric
+    select: average(aws.ec2.NetworkIn)
+    eventId: entity.guid
   hidden: true
 networkOutEc2:
   title: Network Out EC2
   unit: BYTES_PER_SECOND
   query:
-    from: ComputeSample
-    select: average(provider.networkOutBytes.Average)
-    eventId: entityGuid
+    from: Metric
+    select: average(aws.ec2.NetworkOut)
+    eventId: entity.guid
   hidden: true
 networkTrafficEc2:
   title: Network Traffic EC2
@@ -99,17 +99,17 @@ networkInAzure:
   title: Network In Azure
   unit: BYTES_PER_SECOND
   query:
-    from: AzureVirtualMachineSample
-    select: average(networkInBytes.Average)
-    eventId: entityGuid
+    from: Metric
+    select: average(azure.compute.virtualmachines.NetworkIn)
+    eventId: entity.guid
   hidden: true
 networkOutAzure:
   title: Network Out Azure
   unit: BYTES_PER_SECOND
   query:
-    from: AzureVirtualMachineSample
-    select: average(networkOutBytes.Average)
-    eventId: entityGuid
+    from: Metric
+    select: average(azure.compute.virtualmachines.NetworkOut)
+    eventId: entity.guid
   hidden: true
 networkTrafficAzure:
   title: Network Traffic Azure
@@ -120,17 +120,17 @@ networkInGcp:
   title: Network In GCP
   unit: BYTES_PER_SECOND
   query:
-    from: GcpVirtualMachineSample
-    select: average(instance.network.ReceivedBytes)
-    eventId: entityGuid
+    from: Metric
+    select: average(gcp.compute.instance.network.received_bytes_count)
+    eventId: entity.guid
   hidden: true
 networkOutGcp:
   title: Network Out GCP
   unit: BYTES_PER_SECOND
   query:
-    from: GcpVirtualMachineSample
-    select: average(instance.network.SentBytes)
-    eventId: entityGuid
+    from: Metric
+    select: average(gcp.compute.instance.network.sent_bytes_count)
+    eventId: entity.guid
   hidden: true
 networkTrafficGcp:
   title: Network Traffic GCP


### PR DESCRIPTION
### Relevant information

Migrate the summary metrics definition of the Infra host entity to the new `Metric` syntax.
We're not migrating the golden metrics because the service is not ready for the new format yet.

### Checklist

* [ ] I've read the guidelines and understand the acceptance criteria.
* [ ] The value of the attribute marked as `identifier` will be unique and valid. 
* [ ] I've confirmed that my entity type wasn't already defined. If it is I'm providing an
 explanation above.
