### PR TITLE
Remove src_addr from EXT-ROUTER

### DIFF
--- a/definitions/ext-router/definition.yml
+++ b/definitions/ext-router/definition.yml
@@ -11,9 +11,6 @@ synthesis:
   - attribute: provider
     value: kentik-router
 
-  tags:
-    src_addr:
-
 compositeMetrics:
   goldenMetrics:
   - golden_metrics.yml

--- a/definitions/ext-router/definition.yml
+++ b/definitions/ext-router/definition.yml
@@ -16,6 +16,3 @@ compositeMetrics:
   - golden_metrics.yml
   summaryMetrics:
   - summary_metrics.yml
-
-goldenTags:
-- src_addr


### PR DESCRIPTION
We've found that this attribute contains a very wide range IPs, which doesn't seem to be what you'd expect for a router.  E.g. we're seeing the entire space of IPs in various ranges, like 10.1.1.0/24 and others for the same entity.  Our suspicion is that this value is the src_addr of TCP flows / devices that the router may be talking to / have entries in its MAC table, etc.

This is problematic for us as the tag will have a lot of churn (e.g. we're seeing millions of changes per minute for an account with just 250 routers) and cause excessive writes to the entity store (which works under the assumption of storing objects that don't change that often).

We're removing this for now so that we can re-enable the entity type.

### Relevant information

Describe what you have done and any details that you think are relevant or that you might want to discuss with us. 

### Checklist

* [ ] I've read the guidelines and understand the acceptance criteria.
* [ ] The value of the attribute marked as `identifier` will be unique and valid. 
* [ ] I've confirmed that my entity type wasn't already defined. If it is I'm providing an
 explanation above.
