### PR TITLE
Add dashboard templates for multiple K8s entities

### DIFF
--- a/definitions/infra-kubernetes_daemonset/dashboard.json
+++ b/definitions/infra-kubernetes_daemonset/dashboard.json
@@ -1,0 +1,138 @@
+{
+  "name": "Kubernetes daemonset",
+  "description": null,
+  "pages": [
+    {
+      "name": "Kubernetes daemonset",
+      "description": null,
+      "widgets": [
+        {
+          "visualization": {
+            "id": "viz.billboard"
+          },
+          "layout": {
+            "column": 1,
+            "row": 1,
+            "height": 3,
+            "width": 4
+          },
+          "title": "",
+          "rawConfiguration": {
+            "dataFormatters": [],
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "FROM Metric SELECT latest(k8s.daemonset.createdAt) as 'createdAt'"
+              }
+            ],
+            "thresholds": []
+          }
+        },
+        {
+          "visualization": {
+            "id": "viz.line"
+          },
+          "layout": {
+            "column": 5,
+            "row": 1,
+            "height": 3,
+            "width": 4
+          },
+          "title": "Scheduled pods",
+          "rawConfiguration": {
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "FROM Metric SELECT max(k8s.daemonset.podsMissing) as 'podsMissing', min(k8s.daemonset.podsScheduled) as 'podsScheduled', latest(k8s.daemonset.podsDesired) as 'podsDesired' TIMESERIES"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "visualization": {
+            "id": "viz.line"
+          },
+          "layout": {
+            "column": 9,
+            "row": 1,
+            "height": 3,
+            "width": 4
+          },
+          "title": "Scheduling status",
+          "rawConfiguration": {
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "FROM Metric SELECT max(k8s.daemonset.podsUpdatedScheduled) as 'podsUpdatedScheduled', max(k8s.daemonset.podsMisscheduled) as 'podsMisscheduled' TIMESERIES"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "visualization": {
+            "id": "viz.line"
+          },
+          "layout": {
+            "column": 1,
+            "row": 4,
+            "height": 3,
+            "width": 4
+          },
+          "title": "Pods availability",
+          "rawConfiguration": {
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "FROM Metric SELECT min(k8s.daemonset.podsAvailable) as 'podsAvailable', min(k8s.daemonset.podsReady) as 'podsReady', max(k8s.daemonset.podsUnavailable) as 'podsUnavailable' TIMESERIES"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "visualization": {
+            "id": "viz.line"
+          },
+          "layout": {
+            "column": 5,
+            "row": 4,
+            "height": 3,
+            "width": 4
+          },
+          "title": "Generation",
+          "rawConfiguration": {
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "FROM Metric SELECT max(k8s.daemonset.metadataGeneration) as 'metadataGeneration' TIMESERIES"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/definitions/infra-kubernetes_daemonset/definition.yml
+++ b/definitions/infra-kubernetes_daemonset/definition.yml
@@ -33,3 +33,6 @@ synthesis:
       multiValue: false
     newrelic.agentVersion:
       multiValue: false
+dashboardTemplates:
+  newRelic:
+    template: dashboard.json

--- a/definitions/infra-kubernetes_deployment/dashboard.json
+++ b/definitions/infra-kubernetes_deployment/dashboard.json
@@ -1,0 +1,112 @@
+{
+  "name": "Kubernetes deployment",
+  "description": null,
+  "pages": [
+    {
+      "name": "Kubernetes deployment",
+      "description": null,
+      "widgets": [
+        {
+          "visualization": {
+            "id": "viz.billboard"
+          },
+          "layout": {
+            "column": 1,
+            "row": 1,
+            "height": 4,
+            "width": 6
+          },
+          "title": "",
+          "rawConfiguration": {
+            "dataFormatters": [],
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "FROM Metric SELECT latest(k8s.deployment.createdAt) as 'createdAt'"
+              }
+            ],
+            "thresholds": []
+          }
+        },
+        {
+          "visualization": {
+            "id": "viz.line"
+          },
+          "layout": {
+            "column": 7,
+            "row": 1,
+            "height": 4,
+            "width": 6
+          },
+          "title": "Pods rollout",
+          "rawConfiguration": {
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "FROM Metric SELECT latest(k8s.deployment.podsUpdated) as 'podsUpdated' TIMESERIES"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "visualization": {
+            "id": "viz.line"
+          },
+          "layout": {
+            "column": 1,
+            "row": 5,
+            "height": 4,
+            "width": 6
+          },
+          "title": "Pods schedule ",
+          "rawConfiguration": {
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "FROM Metric SELECT latest(k8s.deployment.podsTotal) as 'podsTotal', latest(k8s.deployment.podsDesired) as 'podsDesired', latest(k8s.deployment.podsMissing) as 'podsMissing' TIMESERIES"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "visualization": {
+            "id": "viz.line"
+          },
+          "layout": {
+            "column": 7,
+            "row": 5,
+            "height": 4,
+            "width": 6
+          },
+          "title": "Pods availability",
+          "rawConfiguration": {
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "FROM Metric SELECT latest(k8s.deployment.podsUnavailable) as 'podsUnavailable', latest(k8s.deployment.podsMaxUnavailable) as 'podsMaxUnavailable', latest(k8s.deployment.podsAvailable) as 'podsAvailable' TIMESERIES"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/definitions/infra-kubernetes_deployment/definition.yml
+++ b/definitions/infra-kubernetes_deployment/definition.yml
@@ -35,3 +35,6 @@ synthesis:
       multiValue: false
     newrelic.agentVersion:
       multiValue: false
+dashboardTemplates:
+  newRelic:
+    template: dashboard.json

--- a/definitions/infra-kubernetes_pod/dashboard.json
+++ b/definitions/infra-kubernetes_pod/dashboard.json
@@ -1,0 +1,112 @@
+{
+  "name": "Kubernetes pod",
+  "description": null,
+  "pages": [
+    {
+      "name": "Kubernetes pod",
+      "description": null,
+      "widgets": [
+        {
+          "visualization": {
+            "id": "viz.billboard"
+          },
+          "layout": {
+            "column": 1,
+            "row": 1,
+            "height": 3,
+            "width": 4
+          },
+          "title": "Current status",
+          "rawConfiguration": {
+            "dataFormatters": [],
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "FROM Metric SELECT latest(k8s.status) as 'status', latest(startTime) as 'startTime' WHERE metricName = 'k8s.pod.startTime'"
+              }
+            ],
+            "thresholds": []
+          }
+        },
+        {
+          "visualization": {
+            "id": "viz.line"
+          },
+          "layout": {
+            "column": 5,
+            "row": 1,
+            "height": 3,
+            "width": 8
+          },
+          "title": "Status over time",
+          "rawConfiguration": {
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "FROM Metric SELECT 1 WHERE metricName = 'k8s.pod.startTime' facet k8s.status TIMESERIES"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "visualization": {
+            "id": "viz.line"
+          },
+          "layout": {
+            "column": 1,
+            "row": 4,
+            "height": 3,
+            "width": 6
+          },
+          "title": "Pod readiness & status",
+          "rawConfiguration": {
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "FROM Metric SELECT min(k8s.pod.isReady) as 'Ready', min(k8s.pod.isScheduled) as 'Scheduled' TIMESERIES"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "visualization": {
+            "id": "viz.line"
+          },
+          "layout": {
+            "column": 7,
+            "row": 4,
+            "height": 3,
+            "width": 6
+          },
+          "title": "Network",
+          "rawConfiguration": {
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "FROM Metric SELECT max(k8s.pod.netRxBytesPerSecond) / 1000 AS 'Received KBps', max(k8s.pod.netTxBytesPerSecond) / 1000 AS 'Transmitted KBps', max(k8s.pod.netErrorsPerSecond) AS 'Errors / sec' TIMESERIES"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/definitions/infra-kubernetes_pod/definition.yml
+++ b/definitions/infra-kubernetes_pod/definition.yml
@@ -45,3 +45,6 @@ synthesis:
     host.instanceType:
     aws.region:
       multiValue: false
+dashboardTemplates:
+  newRelic:
+    template: dashboard.json

--- a/definitions/infra-kubernetes_statefulset/dashboard.json
+++ b/definitions/infra-kubernetes_statefulset/dashboard.json
@@ -1,0 +1,138 @@
+{
+  "name": "Kubernetes statefulset",
+  "description": null,
+  "pages": [
+    {
+      "name": "Kubernetes statefulset",
+      "description": null,
+      "widgets": [
+        {
+          "visualization": {
+            "id": "viz.billboard"
+          },
+          "layout": {
+            "column": 1,
+            "row": 1,
+            "height": 3,
+            "width": 4
+          },
+          "title": "",
+          "rawConfiguration": {
+            "dataFormatters": [],
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "FROM Metric SELECT latest(k8s.statefulset.createdAt) as 'createdAt'"
+              }
+            ],
+            "thresholds": []
+          }
+        },
+        {
+          "visualization": {
+            "id": "viz.line"
+          },
+          "layout": {
+            "column": 5,
+            "row": 1,
+            "height": 3,
+            "width": 4
+          },
+          "title": "Updated replicas",
+          "rawConfiguration": {
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "FROM Metric SELECT sum(k8s.statefulset.podsUpdated) as 'podsUpdated' TIMESERIES"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "visualization": {
+            "id": "viz.line"
+          },
+          "layout": {
+            "column": 9,
+            "row": 1,
+            "height": 3,
+            "width": 4
+          },
+          "title": "Replicas availability",
+          "rawConfiguration": {
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "FROM Metric SELECT min(k8s.statefulset.podsReady) as 'podsReady' TIMESERIES"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "visualization": {
+            "id": "viz.line"
+          },
+          "layout": {
+            "column": 1,
+            "row": 4,
+            "height": 3,
+            "width": 4
+          },
+          "title": "Replicas count",
+          "rawConfiguration": {
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "FROM Metric SELECT max(k8s.statefulset.podsMissing) as 'podsMissing', latest(k8s.statefulset.podsDesired) as 'podsDesired', min(k8s.statefulset.podsCurrent) as 'podsCurrent' TIMESERIES"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "visualization": {
+            "id": "viz.line"
+          },
+          "layout": {
+            "column": 5,
+            "row": 4,
+            "height": 3,
+            "width": 4
+          },
+          "title": "Generation",
+          "rawConfiguration": {
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "FROM Metric SELECT max(k8s.statefulset.metadataGeneration) as 'metadataGeneration' TIMESERIES"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/definitions/infra-kubernetes_statefulset/definition.yml
+++ b/definitions/infra-kubernetes_statefulset/definition.yml
@@ -27,3 +27,6 @@ synthesis:
       multiValue: false
     newrelic.agentVersion:
       multiValue: false
+dashboardTemplates:
+  newRelic:
+    template: dashboard.json


### PR DESCRIPTION
### Relevant information

Adding dashboard definitions for the following Kubernetes entities:

- Kubernetes pod
- Kubernetes deployment
- Kubernetes daemonset
- Kubernetes statefulset

### Checklist

* [ ] I've read the guidelines and understand the acceptance criteria.
* [ ] The value of the attribute marked as `identifier` will be unique and valid. 
* [ ] I've confirmed that my entity type wasn't already defined. If it is I'm providing an
 explanation above.
