### PR TITLE
Fix event name typo

### DIFF
--- a/definitions/ext-rf_scanner/definition.yml
+++ b/definitions/ext-rf_scanner/definition.yml
@@ -21,7 +21,7 @@ synthesis:
   conditions:
     # The attribute’s value must match the provided value
     - attribute: eventType
-      prefix: "THD_RF_TRANSACTIONS"
+      prefix: "THD_RF_TRANSACTION"
 
   # Telemetry attributes that should be extracted into entity tags.
   tags:


### PR DESCRIPTION
### Relevant information

THD_RF_TRANSACTION**S** -> THD_RF_TRANSACTION (the correct name of the event)
