### PR TITLE
Fix widget size in dashboards

### DIFF
--- a/definitions/ext-pihole/dashboard.json
+++ b/definitions/ext-pihole/dashboard.json
@@ -13,8 +13,8 @@
           "layout": {
             "column": 1,
             "row": 1,
-            "height": 6,
-            "width": 12
+            "height": 3,
+            "width": 4
           },
           "title": "Total DNS requests",
           "rawConfiguration": {
@@ -31,10 +31,10 @@
             "id": "viz.billboard"
           },
           "layout": {
-            "column": 13,
+            "column": 5,
             "row": 1,
-            "height": 6,
-            "width": 12
+            "height": 3,
+            "width": 4
           },
           "title": "Blocked DNS requests",
           "rawConfiguration": {
@@ -51,10 +51,10 @@
             "id": "viz.billboard"
           },
           "layout": {
-            "column": 25,
+            "column": 9,
             "row": 1,
-            "height": 6,
-            "width": 12
+            "height": 3,
+            "width": 4
           },
           "title": "% blocked requests",
           "rawConfiguration": {
@@ -71,10 +71,10 @@
             "id": "viz.billboard"
           },
           "layout": {
-            "column": 37,
-            "row": 1,
-            "height": 6,
-            "width": 12
+            "column": 1,
+            "row": 4,
+            "height": 3,
+            "width": 4
           },
           "title": "Domains on blocklist",
           "rawConfiguration": {
@@ -91,10 +91,10 @@
             "id": "viz.line"
           },
           "layout": {
-            "column": 1,
-            "row": 7,
+            "column": 5,
+            "row": 4,
             "height": 9,
-            "width": 12
+            "width": 4
           },
           "title": "DNS requests",
           "rawConfiguration": {
@@ -111,10 +111,10 @@
             "id": "viz.line"
           },
           "layout": {
-            "column": 13,
-            "row": 7,
+            "column": 9,
+            "row": 4,
             "height": 9,
-            "width": 12
+            "width": 4
           },
           "title": "Requests blocked",
           "rawConfiguration": {
@@ -131,10 +131,10 @@
             "id": "viz.line"
           },
           "layout": {
-            "column": 25,
+            "column": 1,
             "row": 7,
             "height": 9,
-            "width": 12
+            "width": 4
           },
           "title": "Requests forwarded",
           "rawConfiguration": {
@@ -151,10 +151,10 @@
             "id": "viz.line"
           },
           "layout": {
-            "column": 37,
+            "column": 5,
             "row": 7,
             "height": 9,
-            "width": 12
+            "width": 4
           },
           "title": "Requests cached",
           "rawConfiguration": {
@@ -171,10 +171,10 @@
             "id": "viz.line"
           },
           "layout": {
-            "column": 1,
-            "row": 16,
-            "height": 9,
-            "width": 12
+            "column": 9,
+            "row": 7,
+            "height": 3,
+            "width": 4
           },
           "title": "Cumulative DNS requests",
           "rawConfiguration": {
@@ -191,10 +191,10 @@
             "id": "viz.line"
           },
           "layout": {
-            "column": 13,
-            "row": 16,
-            "height": 9,
-            "width": 12
+            "column": 1,
+            "row": 10,
+            "height": 3,
+            "width": 4
           },
           "title": "Cumulative requests blocked",
           "rawConfiguration": {
@@ -211,10 +211,10 @@
             "id": "viz.line"
           },
           "layout": {
-            "column": 25,
-            "row": 16,
-            "height": 9,
-            "width": 12
+            "column": 5,
+            "row": 10,
+            "height": 3,
+            "width": 4
           },
           "title": "Cumulative requests forwarded",
           "rawConfiguration": {
@@ -231,10 +231,10 @@
             "id": "viz.line"
           },
           "layout": {
-            "column": 37,
-            "row": 16,
-            "height": 9,
-            "width": 12
+            "column": 9,
+            "row": 10,
+            "height": 3,
+            "width": 4
           },
           "title": "Cumulative requests cached",
           "rawConfiguration": {


### PR DESCRIPTION
### Relevant information

During the translation to the new format the widgets for the ext-pihole dashboard became huge, fixing it here. 
