### PR TITLE
Add Kubernetes cluster and namespaces tags for Pixie services.

### DIFF
--- a/definitions/ext-service/definition.yml
+++ b/definitions/ext-service/definition.yml
@@ -53,6 +53,11 @@ synthesis:
       conditions:
         - attribute: instrumentation.provider
           value: pixie
+      tags:
+        k8s.cluster.name:
+          entityTagName: k8s.clusterName
+        k8s.namespace.name:
+          entityTagName: k8s.namespaceName
 
 compositeMetrics:
   goldenMetrics:


### PR DESCRIPTION
### Relevant information

This PR adds Kubernetes tags that are aligned with the Infra Kubernetes tags to the Pixie services.

### Checklist

* [x] I've read the guidelines and understand the acceptance criteria.
* [x] The value of the attribute marked as `identifier` will be unique and valid. 
* [x] I've confirmed that my entity type wasn't already defined. If it is I'm providing an
 explanation above.
