### PR TITLE
Add support for FOUR_HOURS entity expiration time

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,6 +275,7 @@ configuration:
 By default, entities are automatically deleted if we reach 8 days without receiving any telemetry from them. 
 If this doesn't suit your needs you may set the `entityExpirationTime` to one of the following values:  
 
+- `FOUR_HOURS`
 - `DAILY`
 - `EIGHT_DAYS` (default)
 - `QUARTERLY`

--- a/definitions/infra-container/definition.yml
+++ b/definitions/infra-container/definition.yml
@@ -71,5 +71,5 @@ compositeMetrics:
   - summary_metrics.yml
 
 configuration:
-  entityExpirationTime: DAILY
+  entityExpirationTime: FOUR_HOURS
   alertable: true

--- a/definitions/infra-kubernetes_pod/definition.yml
+++ b/definitions/infra-kubernetes_pod/definition.yml
@@ -1,7 +1,7 @@
 domain: INFRA
 type: KUBERNETES_POD
 configuration:
-  entityExpirationTime: DAILY
+  entityExpirationTime: FOUR_HOURS
   alertable: true
 goldenTags:
   - k8s.status

--- a/validator/schemas/entity-schema-v1.json
+++ b/validator/schemas/entity-schema-v1.json
@@ -337,7 +337,7 @@
           "$id": "#/properties/configuration/properties/entityExpirationTime",
           "type": "string",
           "title": "Entity expiration Time",
-          "enum": ["DAILY", "EIGHT_DAYS", "QUARTERLY", "MANUAL"]
+          "enum": ["FOUR_HOURS","DAILY", "EIGHT_DAYS", "QUARTERLY", "MANUAL"]
         },
         "alertable": {
           "$id": "#/properties/configuration/properties/alertable",


### PR DESCRIPTION
### Relevant information

- Add support for FOUR_HOURS entity expiration time
- Change infra-container and infra-k8s_pod expiration time from DAILY to FOUR_HOURS