### PR TITLE
Added more synthesis rules for pi-hole entities

### DIFF
--- a/definitions/ext-pihole/dashboard.json
+++ b/definitions/ext-pihole/dashboard.json
@@ -93,7 +93,7 @@
           "layout": {
             "column": 1,
             "row": 3,
-            "height": 2,
+            "height": 3,
             "width": 3
           },
           "title": "DNS requests",
@@ -113,7 +113,7 @@
           "layout": {
             "column": 4,
             "row": 3,
-            "height": 2,
+            "height": 3,
             "width": 3
           },
           "title": "Requests blocked",
@@ -133,7 +133,7 @@
           "layout": {
             "column": 7,
             "row": 3,
-            "height": 2,
+            "height": 3,
             "width": 3
           },
           "title": "Requests forwarded",
@@ -153,7 +153,7 @@
           "layout": {
             "column": 10,
             "row": 3,
-            "height": 2,
+            "height": 3,
             "width": 3
           },
           "title": "Requests cached",
@@ -173,7 +173,7 @@
           "layout": {
             "column": 1,
             "row": 5,
-            "height": 2,
+            "height": 3,
             "width": 3
           },
           "title": "Cumulative DNS requests",
@@ -193,7 +193,7 @@
           "layout": {
             "column": 4,
             "row": 5,
-            "height": 2,
+            "height": 3,
             "width": 3
           },
           "title": "Cumulative requests blocked",
@@ -213,7 +213,7 @@
           "layout": {
             "column": 7,
             "row": 5,
-            "height": 2,
+            "height": 3,
             "width": 3
           },
           "title": "Cumulative requests forwarded",
@@ -233,7 +233,7 @@
           "layout": {
             "column": 10,
             "row": 5,
-            "height": 4,
+            "height": 3,
             "width": 3
           },
           "title": "Cumulative requests cached",

--- a/definitions/ext-pihole/definition.yml
+++ b/definitions/ext-pihole/definition.yml
@@ -10,17 +10,16 @@ synthesis:
       conditions:
         - attribute: instrumentation.provider
           value: prometheus
+        - attribute: metricName
+          prefix: pihole_
 
     # telemetry with piHoleName attribute
     - identifier: piHoleName
       name: piHoleName
       encodeIdentifierInGUID: true
       conditions:
-        - attribute: serviceName
-
-  conditions:
-    - attribute: metricName
-      prefix: pihole_
+        - attribute: metricName
+          prefix: pihole_
 
 dashboardTemplates:
   newRelic:

--- a/definitions/ext-pihole/definition.yml
+++ b/definitions/ext-pihole/definition.yml
@@ -3,19 +3,16 @@ type: PIHOLE
 
 synthesis:
   rules:
-    # telemetry from prometheus exporter
-    - identifier: hostname
-      name: hostname
-      encodeIdentifierInGUID: true
-      conditions:
-        - attribute: instrumentation.provider
-          value: prometheus
-        - attribute: metricName
-          prefix: pihole_
-
     # telemetry with piHoleName attribute
     - identifier: piHoleName
       name: piHoleName
+      encodeIdentifierInGUID: true
+      conditions:
+        - attribute: piHoleName
+
+    # telemetry from prometheus exporter
+    - identifier: hostname
+      name: hostname
       encodeIdentifierInGUID: true
       conditions:
         - attribute: metricName

--- a/definitions/ext-pihole/definition.yml
+++ b/definitions/ext-pihole/definition.yml
@@ -2,12 +2,25 @@ domain: EXT
 type: PIHOLE
 
 synthesis:
-  name: piHoleName
-  identifier: piHoleName
+  rules:
+    # telemetry from prometheus exporter
+    - identifier: hostname
+      name: hostname
+      encodeIdentifierInGUID: true
+      conditions:
+        - attribute: instrumentation.provider
+          value: prometheus
+
+    # telemetry with piHoleName attribute
+    - identifier: piHoleName
+      name: piHoleName
+      encodeIdentifierInGUID: true
+      conditions:
+        - attribute: serviceName
 
   conditions:
-  - attribute: metricName
-    prefix: pihole_
+    - attribute: metricName
+      prefix: pihole_
 
 dashboardTemplates:
   newRelic:
@@ -15,9 +28,9 @@ dashboardTemplates:
 
 compositeMetrics:
   goldenMetrics:
-  - golden_metrics.yml
+    - golden_metrics.yml
   summaryMetrics:
-  - summary_metrics.yml
+    - summary_metrics.yml
 
 configuration:
   entityExpirationTime: EIGHT_DAYS


### PR DESCRIPTION
### Relevant information

I've added a synthesis rule to support prometheus as a data source.

So far in order to create pi-hole entities the `metricAPI` was used adding the attribute `piHoleName` to the metrics being sent to New Relic, so creating the definition file was fairly easy. The Metrics looked like this until now:
```
{
    "metricName": "pihole_domains_being_blocked",
    "newrelic.source": "metricAPI",
    "piHoleName": "foo_bar",
    "pihole_domains_being_blocked": {
        "type": "gauge",
        "count": 1,
        "sum": 79808,
        "min": 79808,
        "max": 79808,
        "latest": 79808
    },
    "timestamp": 1619094002120
},
```
Using the prometheus exporter leads to things that look a bit different:
```
{
    "hostname": "host.docker.internal",
    "instance": "host.docker.internal:9617",
    "instrumentation.name": "remote-write",
    "instrumentation.provider": "prometheus",
    "instrumentation.source": "XXXXXXXXXXX",
    "instrumentation.version": "0.0.2",
    "job": "pihole",
    "metricName": "pihole_domains_being_blocked",
    "newrelic.source": "prometheusAPI",
    "pihole_domains_being_blocked": {
        "type": "gauge",
        "count": 1,
        "sum": 79808,
        "min": 79808,
        "max": 79808,
        "latest": 79808
    },
    "prometheus_server": "XXXXXXX",
    "timestamp": 1619093996920
}
```
The goal with this changes is to try to first match by the `piHoleName` attribute and if that doesn't work then match by `metricName` prefixed by `pihole_`

I've also fixed the dashboard template which was a bit broken.

### Checklist

* [x] I've read the guidelines and understand the acceptance criteria.
* [x] The value of the attribute marked as `identifier` will be unique and valid. 
* [x] I've confirmed that my entity type wasn't already defined. If it is I'm providing an
 explanation above.
