### PR TITLE
Cleaning up golden and summary metrics from Services.

### DIFF
--- a/definitions/ext-service/golden_metrics.yml
+++ b/definitions/ext-service/golden_metrics.yml
@@ -1,33 +1,33 @@
 throughput:
-  title: Throughput
+  title: Throughput (rpm)
   queries:
     opentelemetry:
-      select: count(*)
+      select: rate(count(*), 1 minute)
       from: Span
       where: span.kind LIKE 'server' OR span.kind LIKE 'consumer' OR kind LIKE 'server' OR kind LIKE 'consumer'
     kamon-agent:
-      select: sum(http.server.requests)
+      select: rate(sum(http.server.requests), 1 minute)
       from: Metric
     micrometer:
-      select: sum(http.server.requests)
+      select: rate(sum(http.server.requests), 1 minute)
       from: Metric
     pixie:
-      select: count(http.server.duration)
+      select: rate(count(http.server.duration), 1 minute)
       from: Metric
 errorRate:
-  title: Error rate
+  title: Error rate (%)
   queries:
     opentelemetry:
-      select: filter(count(*), where error.message IS NOT NULL) / count(*)
+      select: filter(count(*), where error.message IS NOT NULL) / count(*) * 100
       from: Span
     kamon-agent:
-      select: filter(sum(http.server.requests), where http.status_code = '5xx') / sum(http.server.requests)
+      select: filter(sum(http.server.requests), where http.status_code = '5xx') / sum(http.server.requests) * 100
       from: Metric
     micrometer:
-      select: filter(sum(http.server.requests), where exception IS NOT NULL and exception != 'None') / sum(http.server.requests)
+      select: filter(sum(http.server.requests), where exception IS NOT NULL and exception != 'None') / sum(http.server.requests) * 100
       from: Metric
     pixie:
-      select: filter(count(http.server.duration), where http.status_code >= 400 AND http.status_code != 404) / count(http.server.duration)
+      select: filter(count(http.server.duration), where http.status_code >= 400 AND http.status_code != 404) / count(http.server.duration) * 100
       from: Metric
 responseTimeMs:
   title: Response time (ms)

--- a/definitions/ext-service/summary_metrics.yml
+++ b/definitions/ext-service/summary_metrics.yml
@@ -29,19 +29,19 @@ errorRate:
   unit: PERCENTAGE
   queries:
     opentelemetry:
-      select: filter(count(*), where error.message IS NOT NULL) / count(*)
+      select: filter(count(*), where error.message IS NOT NULL) / count(*) * 100
       from: Span
       eventId: entity.guid
     kamon-agent:
-      select: filter(sum(http.server.requests), where http.status_code = '5xx') / sum(http.server.requests)
+      select: filter(sum(http.server.requests), where http.status_code = '5xx') / sum(http.server.requests) * 100
       from: Metric
       eventId: entity.guid
     micrometer:
-      select: filter(sum(http.server.requests), where exception IS NOT NULL and exception != 'None') / sum(http.server.requests)
+      select: filter(sum(http.server.requests), where exception IS NOT NULL and exception != 'None') / sum(http.server.requests) * 100
       from: Metric
       eventId: entity.guid
     pixie:
-      select: filter(count(http.server.duration), where http.status_code >= 400 AND http.status_code != 404) / count(http.server.duration)
+      select: filter(count(http.server.duration), where http.status_code >= 400 AND http.status_code != 404) / count(http.server.duration) * 100
       from: Metric
       eventId: entity.guid
 responseTimeMs:


### PR DESCRIPTION
### Relevant information

* In the summary metrics, we are not returning a percentage at the moment so the values are 100x too small in the UI.
* In the golden metrics, some cleanup to make it more consistent with the summary metrics.

### Checklist

* [x] I've read the guidelines and understand the acceptance criteria.
* [x] The value of the attribute marked as `identifier` will be unique and valid. 
* [x] I've confirmed that my entity type wasn't already defined. If it is I'm providing an
 explanation above.
