### PR TITLE
Fix error metrics for Pixie service entities.

### DIFF
--- a/definitions/ext-service/golden_metrics.yml
+++ b/definitions/ext-service/golden_metrics.yml
@@ -27,7 +27,7 @@ errorRate:
       select: (filter(sum(http.server.requests), where exception IS NOT NULL and exception != 'None') * 100) / sum(http.server.requests)
       from: Metric
     pixie:
-      select: (filter(count(http.server.duration), where http.status_code >= 400 AND http.status_code != 404) * 100) / count(http.server.duration)
+      select: (filter(count(http.server.duration), where numeric(http.status_code) >= 400 AND numeric(http.status_code) != 404) * 100) / count(http.server.duration)
       from: Metric
 responseTimeMs:
   title: Response time (ms)

--- a/definitions/ext-service/summary_metrics.yml
+++ b/definitions/ext-service/summary_metrics.yml
@@ -41,7 +41,7 @@ errorRate:
       from: Metric
       eventId: entity.guid
     pixie:
-      select: filter(count(http.server.duration), where http.status_code >= 400 AND http.status_code != 404) / count(http.server.duration) * 100
+      select: filter(count(http.server.duration), where numeric(http.status_code) >= 400 AND numeric(http.status_code) != 404) / count(http.server.duration) * 100
       from: Metric
       eventId: entity.guid
 responseTimeMs:


### PR DESCRIPTION
### Relevant information

Labels on OpenTelemetry Metrics are string values. Hence the http.status_code label on the Pixie http.server.duration metric is a string. We need to cast to a numerical value in order to calculate the error rate correctly.

### Checklist

* [x] I've read the guidelines and understand the acceptance criteria.
* [x] The value of the attribute marked as `identifier` will be unique and valid. 
* [x] I've confirmed that my entity type wasn't already defined. If it is I'm providing an
 explanation above.
