### PR TITLE
Add service.name attribute back to entity synthesis.

### DIFF
--- a/definitions/ext-service/definition.yml
+++ b/definitions/ext-service/definition.yml
@@ -2,6 +2,12 @@ domain: EXT
 type: SERVICE
 synthesis:
   rules:
+    # telemetry with service.name attribute
+    - identifier: service.name
+      name: service.name
+      encodeIdentifierInGUID: true
+      conditions:
+        - attribute: service.name
     # telemetry with service_name attribute
     - identifier: service_name
       name: service_name


### PR DESCRIPTION
### Relevant information

[This was accidentally removed](https://github.com/newrelic-experimental/entity-synthesis-definitions/pull/167/files#diff-83862fddfad52908973b6e798878d27017e1bc00059c37ca0bac82cf4c43c303L5)

We need it added back for ext-services

### Checklist

* [ ] I've read the guidelines and understand the acceptance criteria.
* [ ] The value of the attribute marked as `identifier` will be unique and valid. 
* [ ] I've confirmed that my entity type wasn't already defined. If it is I'm providing an
 explanation above.
