### PR TITLE
Add instrumentation.provider=opentelemetry to ext-service definitions.

### DIFF
--- a/definitions/ext-service/definition.yml
+++ b/definitions/ext-service/definition.yml
@@ -42,6 +42,18 @@ synthesis:
           entityTagName: language
         telemetry.sdk.version:
 
+    # telemetry from opentelemetry provider
+    - identifier: service.name
+      name: service.name
+      encodeIdentifierInGUID: true
+      conditions:
+        - attribute: instrumentation.provider
+          value: opentelemetry
+      tags:
+        telemetry.sdk.language:
+          entityTagName: language
+        telemetry.sdk.version:
+
     # telemetry from kamon-agent provider
     - identifier: service.name
       name: service.name


### PR DESCRIPTION
### Relevant information

This PR stamps an entity guid when instrumentation.provider is opentelemetry

### Checklist

* [ ] I've read the guidelines and understand the acceptance criteria.
* [ ] The value of the attribute marked as `identifier` will be unique and valid. 
* [ ] I've confirmed that my entity type wasn't already defined. If it is I'm providing an
 explanation above.
