### PR TITLE
EXT-SERVICE: match on service.name

### DIFF
--- a/definitions/ext-service/definition.yml
+++ b/definitions/ext-service/definition.yml
@@ -113,7 +113,7 @@ synthesis:
     # in matches that are not actually about services.  We're
     # keeping it for backwards compatibility reasons but it 
     # is being ignored in some internal services while we add
-    # a configuration option to chose the relevant ingestion
+    # a configuration option to choose the relevant ingestion
     # sources for each rule.
     - identifier: service.name
       name: service.name

--- a/definitions/ext-service/definition.yml
+++ b/definitions/ext-service/definition.yml
@@ -107,6 +107,27 @@ synthesis:
         k8s.namespace.name:
           entityTagName: k8s.namespaceName
 
+    # IMPORTANT:
+    # This rule matches on any telemetry with service.name 
+    # which is too broad for some telemetry sources, resulting
+    # in matches that are not actually about services.  We're
+    # keeping it for backwards compatibility reasons but it 
+    # is being ignored in some internal services while we add
+    # a configuration option to chose the relevant ingestion
+    # sources for each rule.
+    - identifier: service.name
+      name: service.name
+      encodeIdentifierInGUID: true
+      conditions:
+        - attribute: service.name
+      tags:
+        telemetry.sdk.name:
+          entityTagName: instrumentation.provider
+        telemetry.sdk.language:
+          entityTagName: language
+        telemetry.sdk.version:
+
+
 compositeMetrics:
   goldenMetrics:
     - golden_metrics.yml


### PR DESCRIPTION
Restoring an original rule that matched based on the pressence of the
attribute.  Added a warning to note that this rule matches too broadly
in some instrumentation sources, and we're ignoring in certain ingestion
paths until we add a configuration in rules that allows selecting the
right ingest paths to apply it.

Signed-off-by: Galo Navarro <gnavarro@newrelic.com>

### Relevant information

Describe what you have done and any details that you think are relevant or that you might want to discuss with us. 

### Checklist

* [x] I've read the guidelines and understand the acceptance criteria.
* [x] The value of the attribute marked as `identifier` will be unique and valid. 
* [x] I've confirmed that my entity type wasn't already defined. If it is I'm providing an
 explanation above.
