### PR TITLE
Fix EXT-ROUTER definition

### DIFF
--- a/definitions/ext-router/definition.yml
+++ b/definitions/ext-router/definition.yml
@@ -9,7 +9,7 @@ synthesis:
       name: device_name
       encodeIdentifierInGUID: true
       conditions:
-        - attribute: instrumentation.provider
+        - attribute: provider
           value: kentik-router
       tags:
         provider:
@@ -23,16 +23,15 @@ synthesis:
         - attribute: instrumentation.provider
           value: mikrotik-router
       tags:
-        provider:
-          entityTagName: instrumentation.provider
-        agentVersion:
-          entityTagName: instrumentation.version
-        model:
-          entityTagName: mikrotik.model
-        boardname:
-          entityTagName: mikrotik.boardname
-        firmware:
-          entityTagName: mikrotik.currentfirmware
+        instrumentation.provider:
+        instrumentation.version:
+          entityTagName: agentVersion
+        mikrotik.model:
+          entityTagName: model
+        mikrotik.boardname:
+          entityTagName: boardname
+        mikrotik.currentfirmware:
+          entityTagName: firmware
 
 compositeMetrics:
   goldenMetrics:


### PR DESCRIPTION
### Relevant information

- Add back the correct attribute for kentik rules (`instrumentation.provider` -> `provider`)
- Fix tags for `mikrotik` rules