### PR TITLE
Fix aws golden metrics

### DIFF
--- a/definitions/infra-awsalb/golden_metrics.yml
+++ b/definitions/infra-awsalb/golden_metrics.yml
@@ -1,25 +1,42 @@
 serverErrors4XxAnd5Xx:
   title: Server errors (4xx and 5xx)
-  query:
-    select: rate(sum((provider.httpCodeElb4XXCount.Sum OR 0) + (provider.httpCodeElb5XXCount.Sum OR 0)),1
-      minute)
-    from: LoadBalancerSample
-    where: provider='Alb'
-    eventId: entityGuid
-    eventName: entityName
+  queries:
+    aws:
+      select: rate(sum(aws.applicationelb.HTTPCode_ELB_4XX_Count) + sum(aws.applicationelb.HTTPCode_ELB_5XX_Count), 1 minute)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+    awsSample:
+      select: rate(sum((provider.httpCodeElb4XXCount.Sum OR 0) + (provider.httpCodeElb5XXCount.Sum OR 0)),1 minute)
+      from: LoadBalancerSample
+      where: provider='Alb'
+      eventId: entityGuid
+      eventName: entityName
 activeConnections:
   title: Active Connections
-  query:
-    select: rate(sum(provider.activeConnectionCount.Sum),1 minute)
-    from: LoadBalancerSample
-    where: provider='Alb'
-    eventId: entityGuid
-    eventName: entityName
+  queries:
+    aws:
+      select: rate(sum(aws.applicationelb.ActiveConnectionCount), 1 minute)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+    awsSample:
+      select: rate(sum(provider.activeConnectionCount.Sum),1 minute)
+      from: LoadBalancerSample
+      where: provider='Alb'
+      eventId: entityGuid
+      eventName: entityName
 rejectedConnections:
   title: Rejected connections
-  query:
-    select: rate(sum(provider.rejectedConnectionCount.Sum),1 minute)
-    from: LoadBalancerSample
-    where: provider='Alb'
-    eventId: entityGuid
-    eventName: entityName
+  queries:
+    aws:
+      select: rate(sum(aws.applicationelb.RejectedConnectionCount), 1 minute)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+    awsSample:
+      select: rate(sum(provider.rejectedConnectionCount.Sum),1 minute)
+      from: LoadBalancerSample
+      where: provider='Alb'
+      eventId: entityGuid
+      eventName: entityName

--- a/definitions/infra-awsalbtargetgroup/golden_metrics.yml
+++ b/definitions/infra-awsalbtargetgroup/golden_metrics.yml
@@ -1,33 +1,56 @@
 serverErrors4XxAnd5Xx:
   title: Server errors (4xx and 5xx)
-  query:
-    select: rate(sum(`provider.httpCodeTarget4XXCount.Sum`) + sum(`provider.httpCodeTarget5XXCount.Sum`),1
-      minute)
-    from: LoadBalancerSample
-    where: provider='AlbTargetGroup'
-    eventId: entityGuid
-    eventName: entityName
+  queries:
+    aws:
+      select: rate(sum(aws.applicationelb.HTTPCode_Target_4XX_Count) + sum(aws.applicationelb.HTTPCode_Target_5XX_Count), 1 minute)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+    awsSample:
+      select: rate(sum(`provider.httpCodeTarget4XXCount.Sum`) + sum(`provider.httpCodeTarget5XXCount.Sum`),1 minute)
+      from: LoadBalancerSample
+      where: provider='AlbTargetGroup'
+      eventId: entityGuid
+      eventName: entityName
 unhealthyHosts:
   title: Unhealthy host count
-  query:
-    select: max(`provider.unHealthyHostCount.Maximum`)
-    from: LoadBalancerSample
-    where: provider='AlbTargetGroup'
-    eventId: entityGuid
-    eventName: entityName
+  queries:
+    aws:
+      select: max(aws.applicationelb.UnHealthyHostCount)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+    awsSample:
+      select: max(`provider.unHealthyHostCount.Maximum`)
+      from: LoadBalancerSample
+      where: provider='AlbTargetGroup'
+      eventId: entityGuid
+      eventName: entityName
 responseTime:
   title: Average response time
-  query:
-    select: average(`provider.targetResponseTime.Average`)
-    from: LoadBalancerSample
-    where: provider='AlbTargetGroup'
-    eventId: entityGuid
-    eventName: entityName
+  queries:
+    aws:
+      select: average(aws.applicationelb.TargetResponseTime)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+    awsSample:
+      select: average(`provider.targetResponseTime.Average`)
+      from: LoadBalancerSample
+      where: provider='AlbTargetGroup'
+      eventId: entityGuid
+      eventName: entityName
 requests:
   title: Requests
-  query:
-    select: rate(sum(provider.requestCountPerTarget.Sum),1 minute)
-    from: LoadBalancerSample
-    where: provider='AlbTargetGroup'
-    eventId: entityGuid
-    eventName: entityName
+  queries:
+    aws:
+      select: rate(sum(aws.applicationelb.RequestCountPerTarget), 1 minute)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+    awsSample:
+      select: rate(sum(provider.requestCountPerTarget.Sum),1 minute)
+      from: LoadBalancerSample
+      where: provider='AlbTargetGroup'
+      eventId: entityGuid
+      eventName: entityName

--- a/definitions/infra-awsapigatewayapi/golden_metrics.yml
+++ b/definitions/infra-awsapigatewayapi/golden_metrics.yml
@@ -16,7 +16,7 @@ errors4XxAnd5Xx:
   title: Errors (4xx and 5xx)
   queries:
     aws:
-      select: sum(aws.apigateway.5XXError.byApi) + sum(aws.apigateway.4XXError.byApi)
+      select: sum(`aws.apigateway.5XXError.byApi`) + sum(`aws.apigateway.4XXError.byApi`)
       from: Metric
       eventId: entity.guid
       eventName: entity.name

--- a/definitions/infra-awsapigatewayapi/golden_metrics.yml
+++ b/definitions/infra-awsapigatewayapi/golden_metrics.yml
@@ -1,24 +1,42 @@
 requests:
   title: Requests
-  query:
-    select: sum(provider.count.SampleCount)
-    from: ApiGatewaySample
-    where: provider='ApiGatewayApi'
-    eventId: entityGuid
-    eventName: entityName
+  queries:
+    aws:
+      select: sum(aws.apigateway.Count.byApi)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+    awsSample:
+      select: sum(provider.count.SampleCount)
+      from: ApiGatewaySample
+      where: provider='ApiGatewayApi'
+      eventId: entityGuid
+      eventName: entityName
 errors4XxAnd5Xx:
   title: Errors (4xx and 5xx)
-  query:
-    select: sum((`provider.5xxError.Sum` OR 0) + (`provider.4xxError.Sum` OR 0))
-    from: ApiGatewaySample
-    where: provider='ApiGatewayApi'
-    eventId: entityGuid
-    eventName: entityName
+  queries:
+    aws:
+      select: sum(aws.apigateway.5XXError.byApi) + sum(aws.apigateway.4XXError.byApi)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+    awsSample:
+      select: sum((`provider.5xxError.Sum` OR 0) + (`provider.4xxError.Sum` OR 0))
+      from: ApiGatewaySample
+      where: provider='ApiGatewayApi'
+      eventId: entityGuid
+      eventName: entityName
 latencyMs:
   title: Latency (ms)
-  query:
-    select: average(provider.latency.Average)
-    from: ApiGatewaySample
-    where: provider='ApiGatewayApi'
-    eventId: entityGuid
-    eventName: entityName
+  queries:
+    aws:
+      select: average(aws.apigateway.Latency.byApi)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+    awsSample:
+      select: average(provider.latency.Average)
+      from: ApiGatewaySample
+      where: provider='ApiGatewayApi'
+      eventId: entityGuid
+      eventName: entityName

--- a/definitions/infra-awsapigatewayresourcewithmetrics/golden_metrics.yml
+++ b/definitions/infra-awsapigatewayresourcewithmetrics/golden_metrics.yml
@@ -1,24 +1,42 @@
 requests:
   title: Requests
-  query:
-    select: sum(provider.count.SampleCount)
-    from: ApiGatewaySample
-    where: provider='ApiGatewayResourceWithMetrics'
-    eventId: entityGuid
-    eventName: entityName
+  queries:
+    aws:
+      select: sum(aws.apigateway.Count.byApi)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+    awsSample:
+      select: sum(provider.count.SampleCount)
+      from: ApiGatewaySample
+      where: provider='ApiGatewayResourceWithMetrics'
+      eventId: entityGuid
+      eventName: entityName
 errors4XxAnd5Xx:
   title: Errors (4xx and 5xx)
-  query:
-    select: sum((`provider.5xxError.Sum` OR 0) + (`provider.4xxError.Sum` OR 0))
-    from: ApiGatewaySample
-    where: provider='ApiGatewayResourceWithMetrics'
-    eventId: entityGuid
-    eventName: entityName
+  queries:
+    aws:
+      select: sum(aws.apigateway.5XXError.byApi) + sum(aws.apigateway.4XXError.byApi)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+    awsSample:
+      select: sum((`provider.5xxError.Sum` OR 0) + (`provider.4xxError.Sum` OR 0))
+      from: ApiGatewaySample
+      where: provider='ApiGatewayResourceWithMetrics'
+      eventId: entityGuid
+      eventName: entityName
 latencyMs:
   title: Latency (ms)
-  query:
-    select: average(provider.latency.Average)
-    from: ApiGatewaySample
-    where: provider='ApiGatewayResourceWithMetrics'
-    eventId: entityGuid
-    eventName: entityName
+  queries:
+    aws:
+      select: average(aws.apigateway.Latency.byApi)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+    awsSample:
+      select: average(provider.latency.Average)
+      from: ApiGatewaySample
+      where: provider='ApiGatewayResourceWithMetrics'
+      eventId: entityGuid
+      eventName: entityName

--- a/definitions/infra-awsapigatewayresourcewithmetrics/golden_metrics.yml
+++ b/definitions/infra-awsapigatewayresourcewithmetrics/golden_metrics.yml
@@ -16,7 +16,7 @@ errors4XxAnd5Xx:
   title: Errors (4xx and 5xx)
   queries:
     aws:
-      select: sum(aws.apigateway.5XXError.byApi) + sum(aws.apigateway.4XXError.byApi)
+      select: sum(`aws.apigateway.5XXError.byApi`) + sum(`aws.apigateway.4XXError.byApi`)
       from: Metric
       eventId: entity.guid
       eventName: entity.name

--- a/definitions/infra-awsapigatewaystage/golden_metrics.yml
+++ b/definitions/infra-awsapigatewaystage/golden_metrics.yml
@@ -16,7 +16,7 @@ errors4XxAnd5Xx:
   title: Errors (4xx and 5xx)
   queries:
     aws:
-      select: sum(aws.apigateway.4XXError.byApi) + sum(aws.apigateway.5XXError.byApi)
+      select: sum(`aws.apigateway.4XXError.byApi`) + sum(`aws.apigateway.5XXError.byApi`)
       from: Metric
       eventId: entity.guid
       eventName: entity.name

--- a/definitions/infra-awsapigatewaystage/golden_metrics.yml
+++ b/definitions/infra-awsapigatewaystage/golden_metrics.yml
@@ -1,24 +1,42 @@
 requests:
   title: Requests
-  query:
-    select: sum(provider.count.SampleCount)
-    from: ApiGatewaySample
-    where: provider='ApiGatewayStage'
-    eventId: entityGuid
-    eventName: entityName
+  queries:
+    aws:
+      select: sum(aws.apigateway.Count.byApi)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+    awsSample:
+      select: sum(provider.count.SampleCount)
+      from: ApiGatewaySample
+      where: provider='ApiGatewayStage'
+      eventId: entityGuid
+      eventName: entityName
 errors4XxAnd5Xx:
   title: Errors (4xx and 5xx)
-  query:
-    select: sum((`provider.4xxError.Sum` OR 0) + (`provider.5xxError.Sum` OR 0))
-    from: ApiGatewaySample
-    where: provider='ApiGatewayStage'
-    eventId: entityGuid
-    eventName: entityName
+  queries:
+    aws:
+      select: sum(aws.apigateway.4XXError.byApi) + sum(aws.apigateway.5XXError.byApi)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+    awsSample:
+      select: sum((`provider.4xxError.Sum` OR 0) + (`provider.5xxError.Sum` OR 0))
+      from: ApiGatewaySample
+      where: provider='ApiGatewayStage'
+      eventId: entityGuid
+      eventName: entityName
 latencyMs:
   title: Latency (ms)
-  query:
-    select: average(provider.latency.Average)
-    from: ApiGatewaySample
-    where: provider='ApiGatewayStage'
-    eventId: entityGuid
-    eventName: entityName
+  queries:
+    aws:
+      select: average(aws.apigateway.Latency.byApi)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+    awsSample:
+      select: average(provider.latency.Average)
+      from: ApiGatewaySample
+      where: provider='ApiGatewayStage'
+      eventId: entityGuid
+      eventName: entityName

--- a/definitions/infra-awsautoscalinggroup/golden_metrics.yml
+++ b/definitions/infra-awsautoscalinggroup/golden_metrics.yml
@@ -1,24 +1,42 @@
 desiredInstances:
   title: Desired instances
-  query:
-    select: max(provider.groupDesiredCapacity.Maximum)
-    from: AutoScalingGroupSample
-    where: provider='AutoScalingGroup'
-    eventId: entityGuid
-    eventName: entityName
+  queries:
+    aws:
+      select: max(aws.autoscaling.GroupDesiredCapacity)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+    awsSample:
+      select: max(provider.groupDesiredCapacity.Maximum)
+      from: AutoScalingGroupSample
+      where: provider='AutoScalingGroup'
+      eventId: entityGuid
+      eventName: entityName
 inServiceInstances:
   title: In service instances
-  query:
-    select: min(provider.groupInServiceInstances.Minimum)
-    from: AutoScalingGroupSample
-    where: provider='AutoScalingGroup'
-    eventId: entityGuid
-    eventName: entityName
+  queries:
+    aws:
+      select: min(aws.autoscaling.GroupInServiceInstances)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+    awsSample:
+      select: min(provider.groupInServiceInstances.Minimum)
+      from: AutoScalingGroupSample
+      where: provider='AutoScalingGroup'
+      eventId: entityGuid
+      eventName: entityName
 pendingInstances:
   title: Pending instances
-  query:
-    select: max(provider.groupStandbyInstances.Maximum)
-    from: AutoScalingGroupSample
-    where: provider='AutoScalingGroup'
-    eventId: entityGuid
-    eventName: entityName
+  queries:
+    aws:
+      select: max(aws.autoscaling.GroupStandbyInstances)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+    awsSample:
+      select: max(provider.groupStandbyInstances.Maximum)
+      from: AutoScalingGroupSample
+      where: provider='AutoScalingGroup'
+      eventId: entityGuid
+      eventName: entityName

--- a/definitions/infra-awscloudfrontdistribution/golden_metrics.yml
+++ b/definitions/infra-awscloudfrontdistribution/golden_metrics.yml
@@ -1,32 +1,56 @@
 requests:
   title: Requests
-  query:
-    select: sum(provider.requests.Sum)
-    from: LoadBalancerSample
-    where: provider='CloudFrontDistribution'
-    eventId: entityGuid
-    eventName: entityName
+  queries:
+    aws:
+      select: sum(aws.cloudfront.Requests)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+    awsSample:
+      select: sum(provider.requests.Sum)
+      from: LoadBalancerSample
+      where: provider='CloudFrontDistribution'
+      eventId: entityGuid
+      eventName: entityName
 totalErrorRate:
   title: Total error rate
-  query:
-    select: average(provider.totalErrorRate.Average)
-    from: LoadBalancerSample
-    where: provider='CloudFrontDistribution'
-    eventId: entityGuid
-    eventName: entityName
+  queries:
+    aws:
+      select: average(aws.cloudfront.TotalErrorRate)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+    awsSample:
+      select: average(provider.totalErrorRate.Average)
+      from: LoadBalancerSample
+      where: provider='CloudFrontDistribution'
+      eventId: entityGuid
+      eventName: entityName
 bytesUploaded:
   title: Uploaded bytes
-  query:
-    select: sum(provider.bytesUploaded.Sum)
-    from: LoadBalancerSample
-    where: provider='CloudFrontDistribution'
-    eventId: entityGuid
-    eventName: entityName
+  queries:
+    aws:
+      select: sum(aws.cloudfront.BytesUploaded)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+    awsSample:
+      select: sum(provider.bytesUploaded.Sum)
+      from: LoadBalancerSample
+      where: provider='CloudFrontDistribution'
+      eventId: entityGuid
+      eventName: entityName
 bytesDownloaded:
   title: Downloaded bytes
-  query:
-    select: sum(provider.bytesDownloaded.Sum)
-    from: LoadBalancerSample
-    where: provider='CloudFrontDistribution'
-    eventId: entityGuid
-    eventName: entityName
+  queries:
+    aws:
+      select: sum(aws.cloudfront.BytesDownloaded)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+    awsSample:
+      select: sum(provider.bytesDownloaded.Sum)
+      from: LoadBalancerSample
+      where: provider='CloudFrontDistribution'
+      eventId: entityGuid
+      eventName: entityName

--- a/definitions/infra-awsdocdbcluster/golden_metrics.yml
+++ b/definitions/infra-awsdocdbcluster/golden_metrics.yml
@@ -1,56 +1,84 @@
-# Important metrics are listed here:
-# https://docs.aws.amazon.com/documentdb/latest/developerguide/monitoring_docdb.html
 cpuUsage:
   title: CPU usage
-  query:
-    select: average(provider.cpuUtilization.Average)
-    from: AwsDocDbClusterSample
-    where: provider='AwsDocDbCluster'
-    eventId: entityGuid
-    eventName: entityName
-  unit: PERCENTAGE
+  queries:
+    aws:
+      select: average(aws.docdb.CPUUtilization.byCluster)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+    awsSample:
+      select: average(provider.cpuUtilization.Average)
+      from: AwsDocDbClusterSample
+      where: provider='AwsDocDbCluster'
+      eventId: entityGuid
+      eventName: entityName
 databaseConnections:
   title: Database connections
-  query:
-    select: average(provider.databaseConnections.Average)
-    from: AwsDocDbClusterSample
-    where: provider='AwsDocDbCluster'
-    eventId: entityGuid
-    eventName: entityName
-  unit: COUNT
+  queries:
+    aws:
+      select: average(aws.docdb.DatabaseConnections.byCluster)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+    awsSample:
+      select: average(provider.databaseConnections.Average)
+      from: AwsDocDbClusterSample
+      where: provider='AwsDocDbCluster'
+      eventId: entityGuid
+      eventName: entityName
 volumeBytesUsed:
   title: Storage consumption
-  query:
-    select: average(provider.volumeBytesUsed.Average)
-    from: AwsDocDbClusterSample
-    where: provider='AwsDocDbCluster'
-    eventId: entityGuid
-    eventName: entityName
-  unit: BYTES
+  queries:
+    aws:
+      select: average(aws.docdb.VolumeBytesUsed.byCluster)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+    awsSample:
+      select: average(provider.volumeBytesUsed.Average)
+      from: AwsDocDbClusterSample
+      where: provider='AwsDocDbCluster'
+      eventId: entityGuid
+      eventName: entityName
 networkThroughput:
   title: Network throughput
-  query:
-    select: average(provider.networkThroughput.Average)
-    from: AwsDocDbClusterSample
-    where: provider='AwsDocDbCluster'
-    eventId: entityGuid
-    eventName: entityName
-  unit: BYTES_PER_SECOND
+  queries:
+    aws:
+      select: average(aws.docdb.NetworkThroughput.byCluster)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+    awsSample:
+      select: average(provider.networkThroughput.Average)
+      from: AwsDocDbClusterSample
+      where: provider='AwsDocDbCluster'
+      eventId: entityGuid
+      eventName: entityName
 writeIops:
   title: Write IOPS
-  query:
-    select: average(provider.writeIOPS.Average)
-    from: AwsDocDbClusterSample
-    where: provider='AwsDocDbCluster'
-    eventId: entityGuid
-    eventName: entityName
-  unit: OPERATIONS_PER_SECOND
+  queries:
+    aws:
+      select: average(aws.docdb.WriteIOPS.byCluster)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+    awsSample:
+      select: average(provider.writeIOPS.Average)
+      from: AwsDocDbClusterSample
+      where: provider='AwsDocDbCluster'
+      eventId: entityGuid
+      eventName: entityName
 readIopos:
   title: Read IOPS
-  query:
-    select: average(provider.readIOPS.Average)
-    from: AwsDocDbClusterSample
-    where: provider='AwsDocDbCluster'
-    eventId: entityGuid
-    eventName: entityName
-  unit: OPERATIONS_PER_SECOND
+  queries:
+    aws:
+      select: average(aws.docdb.ReadIOPS.byCluster)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+    awsSample:
+      select: average(provider.readIOPS.Average)
+      from: AwsDocDbClusterSample
+      where: provider='AwsDocDbCluster'
+      eventId: entityGuid
+      eventName: entityName

--- a/definitions/infra-awsdocdbclusterbyrole/golden_metrics.yml
+++ b/definitions/infra-awsdocdbclusterbyrole/golden_metrics.yml
@@ -1,56 +1,84 @@
-# Important metrics are listed here:
-# https://docs.aws.amazon.com/documentdb/latest/developerguide/monitoring_docdb.html
 cpuUsage:
   title: CPU usage
-  query:
-    select: average(provider.cpuUtilization.Average)
-    from: AwsDocDbClusterSample
-    where: provider='AwsDocDbClusterByRole'
-    eventId: entityGuid
-    eventName: entityName
-  unit: PERCENTAGE
+  queries:
+    aws:
+      select: average(aws.docdb.CPUUtilization.byCluster)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+    awsSample:
+      select: average(provider.cpuUtilization.Average)
+      from: AwsDocDbClusterSample
+      where: provider='AwsDocDbClusterByRole'
+      eventId: entityGuid
+      eventName: entityName
 databaseConnections:
   title: Database connections
-  query:
-    select: average(provider.databaseConnections.Average)
-    from: AwsDocDbClusterSample
-    where: provider='AwsDocDbClusterByRole'
-    eventId: entityGuid
-    eventName: entityName
-  unit: COUNT
+  queries:
+    aws:
+      select: average(aws.docdb.DatabaseConnections.byCluster)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+    awsSample:
+      select: average(provider.databaseConnections.Average)
+      from: AwsDocDbClusterSample
+      where: provider='AwsDocDbClusterByRole'
+      eventId: entityGuid
+      eventName: entityName
 volumeBytesUsed:
   title: Storage consumption
-  query:
-    select: average(provider.volumeBytesUsed.Average)
-    from: AwsDocDbClusterSample
-    where: provider='AwsDocDbClusterByRole'
-    eventId: entityGuid
-    eventName: entityName
-  unit: BYTES
+  queries:
+    aws:
+      select: average(aws.docdb.VolumeBytesUsed.byCluster)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+    awsSample:
+      select: average(provider.volumeBytesUsed.Average)
+      from: AwsDocDbClusterSample
+      where: provider='AwsDocDbClusterByRole'
+      eventId: entityGuid
+      eventName: entityName
 networkThroughput:
   title: Network throughput
-  query:
-    select: average(provider.networkThroughput.Average)
-    from: AwsDocDbClusterSample
-    where: provider='AwsDocDbClusterByRole'
-    eventId: entityGuid
-    eventName: entityName
-  unit: BYTES_PER_SECOND
+  queries:
+    aws:
+      select: average(aws.docdb.NetworkThroughput.byCluster)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+    awsSample:
+      select: average(provider.networkThroughput.Average)
+      from: AwsDocDbClusterSample
+      where: provider='AwsDocDbClusterByRole'
+      eventId: entityGuid
+      eventName: entityName
 writeIops:
   title: Write IOPS
-  query:
-    select: average(provider.writeIOPS.Average)
-    from: AwsDocDbClusterSample
-    where: provider='AwsDocDbClusterByRole'
-    eventId: entityGuid
-    eventName: entityName
-  unit: OPERATIONS_PER_SECOND
+  queries:
+    aws:
+      select: average(aws.docdb.WriteIOPS.byCluster)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+    awsSample:
+      select: average(provider.writeIOPS.Average)
+      from: AwsDocDbClusterSample
+      where: provider='AwsDocDbClusterByRole'
+      eventId: entityGuid
+      eventName: entityName
 readIopos:
   title: Read IOPS
-  query:
-    select: average(provider.readIOPS.Average)
-    from: AwsDocDbClusterSample
-    where: provider='AwsDocDbClusterByRole'
-    eventId: entityGuid
-    eventName: entityName
-  unit: OPERATIONS_PER_SECOND
+  queries:
+    aws:
+      select: average(aws.docdb.ReadIOPS.byCluster)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+    awsSample:
+      select: average(provider.readIOPS.Average)
+      from: AwsDocDbClusterSample
+      where: provider='AwsDocDbClusterByRole'
+      eventId: entityGuid
+      eventName: entityName

--- a/definitions/infra-awsdocdbinstance/golden_metrics.yml
+++ b/definitions/infra-awsdocdbinstance/golden_metrics.yml
@@ -1,56 +1,84 @@
-# Important metrics are listed here:
-# https://docs.aws.amazon.com/documentdb/latest/developerguide/monitoring_docdb.html
 cpuUsage:
   title: CPU usage
-  query:
-    select: average(provider.cpuUtilization.Average)
-    from: AwsDocDbInstanceSample
-    where: provider='AwsDocDbInstance'
-    eventId: entityGuid
-    eventName: entityName
-  unit: PERCENTAGE
+  queries:
+    aws:
+      select: average(aws.docdb.CPUUtilization.byInstance)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+    awsSample:
+      select: average(provider.cpuUtilization.Average)
+      from: AwsDocDbInstanceSample
+      where: provider='AwsDocDbInstance'
+      eventId: entityGuid
+      eventName: entityName
 databaseConnections:
   title: Database connections
-  query:
-    select: average(provider.databaseConnections.Average)
-    from: AwsDocDbInstanceSample
-    where: provider='AwsDocDbInstance'
-    eventId: entityGuid
-    eventName: entityName
-  unit: COUNT
+  queries:
+    aws:
+      select: average(aws.docdb.DatabaseConnections.byInstance)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+    awsSample:
+      select: average(provider.databaseConnections.Average)
+      from: AwsDocDbInstanceSample
+      where: provider='AwsDocDbInstance'
+      eventId: entityGuid
+      eventName: entityName
 volumeBytesUsed:
   title: Storage consumption
-  query:
-    select: average(provider.volumeBytesUsed.Average)
-    from: AwsDocDbInstanceSample
-    where: provider='AwsDocDbInstance'
-    eventId: entityGuid
-    eventName: entityName
-  unit: BYTES
+  queries:
+    aws:
+      select: average(aws.docdb.VolumeBytesUsed.byInstance)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+    awsSample:
+      select: average(provider.volumeBytesUsed.Average)
+      from: AwsDocDbInstanceSample
+      where: provider='AwsDocDbInstance'
+      eventId: entityGuid
+      eventName: entityName
 networkThroughput:
   title: Network throughput
-  query:
-    select: average(provider.networkThroughput.Average)
-    from: AwsDocDbInstanceSample
-    where: provider='AwsDocDbInstance'
-    eventId: entityGuid
-    eventName: entityName
-  unit: BYTES_PER_SECOND
+  queries:
+    aws:
+      select: average(aws.docdb.NetworkThroughput.byInstance)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+    awsSample:
+      select: average(provider.networkThroughput.Average)
+      from: AwsDocDbInstanceSample
+      where: provider='AwsDocDbInstance'
+      eventId: entityGuid
+      eventName: entityName
 writeIops:
   title: Write IOPS
-  query:
-    select: average(provider.writeIOPS.Average)
-    from: AwsDocDbInstanceSample
-    where: provider='AwsDocDbInstance'
-    eventId: entityGuid
-    eventName: entityName
-  unit: OPERATIONS_PER_SECOND
+  queries:
+    aws:
+      select: average(aws.docdb.WriteIOPS.byInstance)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+    awsSample:
+      select: average(provider.writeIOPS.Average)
+      from: AwsDocDbInstanceSample
+      where: provider='AwsDocDbInstance'
+      eventId: entityGuid
+      eventName: entityName
 readIopos:
   title: Read IOPS
-  query:
-    select: average(provider.readIOPS.Average)
-    from: AwsDocDbInstanceSample
-    where: provider='AwsDocDbInstance'
-    eventId: entityGuid
-    eventName: entityName
-  unit: OPERATIONS_PER_SECOND
+  queries:
+    aws:
+      select: average(aws.docdb.ReadIOPS.byInstance)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+    awsSample:
+      select: average(provider.readIOPS.Average)
+      from: AwsDocDbInstanceSample
+      where: provider='AwsDocDbInstance'
+      eventId: entityGuid
+      eventName: entityName

--- a/definitions/infra-awsdynamodbglobalsecondaryindex/golden_metrics.yml
+++ b/definitions/infra-awsdynamodbglobalsecondaryindex/golden_metrics.yml
@@ -1,32 +1,56 @@
 consumedReadCapacityUnits:
   title: Consumed read capacity unit
-  query:
-    select: sum(provider.consumedReadCapacityUnits.Sum)
-    from: DatastoreSample
-    where: provider='DynamoDbGlobalSecondaryIndex'
-    eventId: entityGuid
-    eventName: entityName
+  queries:
+    aws:
+      select: sum(aws.dynamodb.ConsumedReadCapacityUnits.byGlobalSecondaryIndex)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+    awsSample:
+      select: sum(provider.consumedReadCapacityUnits.Sum)
+      from: DatastoreSample
+      where: provider='DynamoDbGlobalSecondaryIndex'
+      eventId: entityGuid
+      eventName: entityName
 provisionedReadCapacityUnits:
   title: Provisioned read capacity unit
-  query:
-    select: sum(provider.provisionedReadCapacityUnits.Average)
-    from: DatastoreSample
-    where: provider='DynamoDbGlobalSecondaryIndex'
-    eventId: entityGuid
-    eventName: entityName
+  queries:
+    aws:
+      select: sum(aws.dynamodb.ProvisionedReadCapacityUnits.byGlobalSecondaryIndex)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+    awsSample:
+      select: sum(provider.provisionedReadCapacityUnits.Average)
+      from: DatastoreSample
+      where: provider='DynamoDbGlobalSecondaryIndex'
+      eventId: entityGuid
+      eventName: entityName
 consumedWriteCapacityUnits:
   title: Consumed write capacity unit
-  query:
-    select: sum(provider.consumedWriteCapacityUnits.Sum)
-    from: DatastoreSample
-    where: provider='DynamoDbGlobalSecondaryIndex'
-    eventId: entityGuid
-    eventName: entityName
+  queries:
+    aws:
+      select: sum(aws.dynamodb.ConsumedWriteCapacityUnits.byGlobalSecondaryIndex)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+    awsSample:
+      select: sum(provider.consumedWriteCapacityUnits.Sum)
+      from: DatastoreSample
+      where: provider='DynamoDbGlobalSecondaryIndex'
+      eventId: entityGuid
+      eventName: entityName
 provisionedWriteCapacityUnits:
   title: Provisioned write capacity unit
-  query:
-    select: sum(provider.provisionedWriteCapacityUnits.Average)
-    from: DatastoreSample
-    where: provider='DynamoDbGlobalSecondaryIndex'
-    eventId: entityGuid
-    eventName: entityName
+  queries:
+    aws:
+      select: sum(aws.dynamodb.ProvisionedWriteCapacityUnits.byGlobalSecondaryIndex)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+    awsSample:
+      select: sum(provider.provisionedWriteCapacityUnits.Average)
+      from: DatastoreSample
+      where: provider='DynamoDbGlobalSecondaryIndex'
+      eventId: entityGuid
+      eventName: entityName

--- a/definitions/infra-awsdynamodbregion/golden_metrics.yml
+++ b/definitions/infra-awsdynamodbregion/golden_metrics.yml
@@ -1,7 +1,7 @@
 systemErrors:
   title: System errors
   query:
-    select: sum(systemErrors.Total)
+    select: sum(provider.systemErrors.Sum)
     from: DatastoreSample
     where: provider='DynamoDbRegion'
     eventId: entityGuid

--- a/definitions/infra-awsdynamodbregion/golden_metrics.yml
+++ b/definitions/infra-awsdynamodbregion/golden_metrics.yml
@@ -1,8 +1,14 @@
 systemErrors:
   title: System errors
-  query:
-    select: sum(provider.systemErrors.Sum)
-    from: DatastoreSample
-    where: provider='DynamoDbRegion'
-    eventId: entityGuid
-    eventName: entityName
+  queries:
+    aws:
+      select: sum(aws.dynamodb.SystemErrors.byRegion)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+    awsSample:
+      select: sum(provider.systemErrors.Sum)
+      from: DatastoreSample
+      where: provider='DynamoDbRegion'
+      eventId: entityGuid
+      eventName: entityName

--- a/definitions/infra-awsdynamodbtable/golden_metrics.yml
+++ b/definitions/infra-awsdynamodbtable/golden_metrics.yml
@@ -1,24 +1,42 @@
 readThrottledRequests:
   title: Read throttled requests
-  query:
-    select: sum(provider.readThrottleEvents.Sum)
-    from: DatastoreSample
-    where: provider='DynamoDbTable'
-    eventId: entityGuid
-    eventName: entityName
+  queries:
+    aws:
+      select: sum(aws.dynamodb.ReadThrottleEvents.byGlobalSecondaryIndex)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+    awsSample:
+      select: sum(provider.readThrottleEvents.Sum)
+      from: DatastoreSample
+      where: provider='DynamoDbTable'
+      eventId: entityGuid
+      eventName: entityName
 writeThrottledRequests:
   title: Write throttled requests
-  query:
-    select: sum(provider.writeThrottleEvents.Sum)
-    from: DatastoreSample
-    where: provider='DynamoDbTable'
-    eventId: entityGuid
-    eventName: entityName
+  queries:
+    aws:
+      select: sum(aws.dynamodb.WriteThrottleEvents.byGlobalSecondaryIndex)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+    awsSample:
+      select: sum(provider.writeThrottleEvents.Sum)
+      from: DatastoreSample
+      where: provider='DynamoDbTable'
+      eventId: entityGuid
+      eventName: entityName
 getitemLatencyMs:
   title: GetItem latency (ms)
-  query:
-    select: average(provider.getSuccessfulRequestLatency.Average)
-    from: DatastoreSample
-    where: provider='DynamoDbTable'
-    eventId: entityGuid
-    eventName: entityName
+  queries:
+    aws:
+      select: average(aws.dynamodb.SuccessfulRequestLatency.get)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+    awsSample:
+      select: average(provider.getSuccessfulRequestLatency.Average)
+      from: DatastoreSample
+      where: provider='DynamoDbTable'
+      eventId: entityGuid
+      eventName: entityName

--- a/definitions/infra-awsebsvolume/golden_metrics.yml
+++ b/definitions/infra-awsebsvolume/golden_metrics.yml
@@ -30,7 +30,7 @@ averageWriteTimeMs:
   title: Average Write Time (ms)
   queries:
     aws:
-      select: 1000 * average(aws.ebs.VolumeTotalWriteTime) / average(aws.ebs.VolumeWriteOps))
+      select: 1000 * average(aws.ebs.VolumeTotalWriteTime) / average(aws.ebs.VolumeWriteOps)
       from: Metric
       eventId: entity.guid
       eventName: entity.name
@@ -44,7 +44,7 @@ averageReadTimeMs:
   title: Average Read Time (ms)
   queries:
     aws:
-      select: 1000 * average(aws.ebs.VolumeTotalReadTime) / average(aws.ebs.VolumeReadOps))
+      select: 1000 * average(aws.ebs.VolumeTotalReadTime) / average(aws.ebs.VolumeReadOps)
       from: Metric
       eventId: entity.guid
       eventName: entity.name

--- a/definitions/infra-awsebsvolume/golden_metrics.yml
+++ b/definitions/infra-awsebsvolume/golden_metrics.yml
@@ -1,32 +1,56 @@
 readAndWriteOperations:
   title: Read and Write Operations
-  query:
-    select: sum((provider.volumeReadOps.Sum OR 0) + (provider.volumeWriteOps.Sum OR 0))
-    from: BlockDeviceSample
-    where: provider='EbsVolume'
-    eventId: entityGuid
-    eventName: entityName
+  queries:
+    aws:
+      select: sum(aws.ebs.VolumeReadOps) + sum(aws.ebs.VolumeWriteOps)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+    awsSample:
+      select: sum((provider.volumeReadOps.Sum OR 0) + (provider.volumeWriteOps.Sum OR 0))
+      from: BlockDeviceSample
+      where: provider='EbsVolume'
+      eventId: entityGuid
+      eventName: entityName
 readAndWriteQueueLength:
   title: Read and Write Queue Length
-  query:
-    select: average(provider.volumeQueueLength.Average)
-    from: BlockDeviceSample
-    where: provider='EbsVolume'
-    eventId: entityGuid
-    eventName: entityName
+  queries:
+    aws:
+      select: average(aws.ebs.VolumeQueueLength)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+    awsSample:
+      select: average(provider.volumeQueueLength.Average)
+      from: BlockDeviceSample
+      where: provider='EbsVolume'
+      eventId: entityGuid
+      eventName: entityName
 averageWriteTimeMs:
   title: Average Write Time (ms)
-  query:
-    select: average(provider.volumeTotalWriteTime.Sum / provider.volumeWriteOps.Sum) * 1000
-    from: BlockDeviceSample
-    where: provider='EbsVolume'
-    eventId: entityGuid
-    eventName: entityName
+  queries:
+    aws:
+      select: 1000 * average(aws.ebs.VolumeTotalWriteTime) / average(aws.ebs.VolumeWriteOps))
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+    awsSample:
+      select: average(provider.volumeTotalWriteTime.Sum / provider.volumeWriteOps.Sum) * 1000
+      from: BlockDeviceSample
+      where: provider='EbsVolume'
+      eventId: entityGuid
+      eventName: entityName
 averageReadTimeMs:
   title: Average Read Time (ms)
-  query:
-    select: average(provider.volumeTotalReadTime.Sum / provider.volumeReadOps.Sum) * 1000
-    from: BlockDeviceSample
-    where: provider='EbsVolume'
-    eventId: entityGuid
-    eventName: entityName
+  queries:
+    aws:
+      select: 1000 * average(aws.ebs.VolumeTotalReadTime) / average(aws.ebs.VolumeReadOps))
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+    awsSample:
+      select: average(provider.volumeTotalReadTime.Sum / provider.volumeReadOps.Sum) * 1000
+      from: BlockDeviceSample
+      where: provider='EbsVolume'
+      eventId: entityGuid
+      eventName: entityName

--- a/definitions/infra-awsecscluster/golden_metrics.yml
+++ b/definitions/infra-awsecscluster/golden_metrics.yml
@@ -1,16 +1,28 @@
 cpuUsage:
   title: CPU usage (%)
-  query:
-    select: average(provider.cpuUtilization.Average)
-    from: ComputeSample
-    where: provider='EcsCluster'
-    eventId: entityGuid
-    eventName: entityName
+  queries:
+    aws:
+      select: average(aws.ec2.CPUUtilization)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+    awsSample:
+      select: average(provider.cpuUtilization.Average)
+      from: ComputeSample
+      where: provider='EcsCluster'
+      eventId: entityGuid
+      eventName: entityName
 memoryUsage:
   title: Memory usage (%)
-  query:
-    select: average(provider.memoryUtilization.Average)
-    from: ComputeSample
-    where: provider='EcsCluster'
-    eventId: entityGuid
-    eventName: entityName
+  queries:
+    aws:
+      select: average(aws.ecs.MemoryUtilization.byCluster)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+    awsSample:
+      select: average(provider.memoryUtilization.Average)
+      from: ComputeSample
+      where: provider='EcsCluster'
+      eventId: entityGuid
+      eventName: entityName

--- a/definitions/infra-awsecscontainerinstance/golden_metrics.yml
+++ b/definitions/infra-awsecscontainerinstance/golden_metrics.yml
@@ -1,16 +1,28 @@
 registeredCpu:
   title: Registered CPUs
-  query:
-    select: average(provider.registeredCpu)
-    from: ComputeSample
-    where: provider='EcsContainerInstance'
-    eventId: entityGuid
-    eventName: entityName
+  queries:
+    aws:
+      select: average(aws.ecs.registeredCpu)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+    awsSample:
+      select: average(provider.registeredCpu)
+      from: ComputeSample
+      where: provider='EcsContainerInstance'
+      eventId: entityGuid
+      eventName: entityName
 registeredMemory:
   title: Registered memory
-  query:
-    select: average(provider.registeredMemory)
-    from: ComputeSample
-    where: provider='EcsContainerInstance'
-    eventId: entityGuid
-    eventName: entityName
+  queries:
+    aws:
+      select: average(aws.ecs.registeredMemory)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+    awsSample:
+      select: average(provider.registeredMemory)
+      from: ComputeSample
+      where: provider='EcsContainerInstance'
+      eventId: entityGuid
+      eventName: entityName

--- a/definitions/infra-awsecsservice/golden_metrics.yml
+++ b/definitions/infra-awsecsservice/golden_metrics.yml
@@ -1,16 +1,28 @@
 cpuUsage:
   title: CPU usage (%)
-  query:
-    select: average(provider.cpuUtilization.Average)
-    from: ComputeSample
-    where: provider='EcsService'
-    eventId: entityGuid
-    eventName: entityName
+  queries:
+    aws:
+      select: average(aws.ec2.CPUUtilization)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+    awsSample:
+      select: average(provider.cpuUtilization.Average)
+      from: ComputeSample
+      where: provider='EcsService'
+      eventId: entityGuid
+      eventName: entityName
 memoryUsage:
   title: Memory usage (%)
-  query:
-    select: average(provider.memoryUtilization.Average)
-    from: ComputeSample
-    where: provider='EcsService'
-    eventId: entityGuid
-    eventName: entityName
+  queries:
+    aws:
+      select: average(aws.ecs.MemoryUtilization.byCluster)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+    awsSample:
+      select: average(provider.memoryUtilization.Average)
+      from: ComputeSample
+      where: provider='EcsService'
+      eventId: entityGuid
+      eventName: entityName

--- a/definitions/infra-awsefsfilesystem/golden_metrics.yml
+++ b/definitions/infra-awsefsfilesystem/golden_metrics.yml
@@ -1,32 +1,56 @@
 iops:
   title: Total I/O (Bytes per sec)
-  query:
-    select: rate(sum(`provider.totalIOBytes.Sum`), 1 second)
-    from: BlockDeviceSample
-    where: provider='EfsFileSystem'
-    eventId: entityGuid
-    eventName: entityName
+  queries:
+    aws:
+      select: rate(sum(aws.efs.TotalIOBytes), 1 second)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+    awsSample:
+      select: rate(sum(`provider.totalIOBytes.Sum`), 1 second)
+      from: BlockDeviceSample
+      where: provider='EfsFileSystem'
+      eventId: entityGuid
+      eventName: entityName
 iolimit:
   title: I/O limit (%)
-  query:
-    select: max(`provider.percentIOLimit.Maximum`)
-    from: BlockDeviceSample
-    where: provider='EfsFileSystem'
-    eventId: entityGuid
-    eventName: entityName
+  queries:
+    aws:
+      select: max(aws.efs.PercentIOLimit)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+    awsSample:
+      select: max(`provider.percentIOLimit.Maximum`)
+      from: BlockDeviceSample
+      where: provider='EfsFileSystem'
+      eventId: entityGuid
+      eventName: entityName
 clientConnections:
   title: Client Connections
-  query:
-    select: sum(`provider.clientConnections.Sum`)
-    from: BlockDeviceSample
-    where: provider='EfsFileSystem'
-    eventId: entityGuid
-    eventName: entityName
+  queries:
+    aws:
+      select: sum(aws.efs.ClientConnections)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+    awsSample:
+      select: sum(`provider.clientConnections.Sum`)
+      from: BlockDeviceSample
+      where: provider='EfsFileSystem'
+      eventId: entityGuid
+      eventName: entityName
 burstCreditBalance:
   title: Burst Credit Balance
-  query:
-    select: average(`provider.burstCreditBalance.Average`)
-    from: BlockDeviceSample
-    where: provider='EfsFileSystem'
-    eventId: entityGuid
-    eventName: entityName
+  queries:
+    aws:
+      select: average(aws.efs.BurstCreditBalance)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+    awsSample:
+      select: average(`provider.burstCreditBalance.Average`)
+      from: BlockDeviceSample
+      where: provider='EfsFileSystem'
+      eventId: entityGuid
+      eventName: entityName

--- a/definitions/infra-awsefsfilesystem/golden_metrics.yml
+++ b/definitions/infra-awsefsfilesystem/golden_metrics.yml
@@ -17,7 +17,7 @@ iolimit:
 clientConnections:
   title: Client Connections
   query:
-    select: max(`provider.clientConnections.Sum`)
+    select: sum(`provider.clientConnections.Sum`)
     from: BlockDeviceSample
     where: provider='EfsFileSystem'
     eventId: entityGuid

--- a/definitions/infra-awselasticachememcachedcluster/golden_metrics.yml
+++ b/definitions/infra-awselasticachememcachedcluster/golden_metrics.yml
@@ -1,40 +1,70 @@
 cpuUtilization:
   title: CPU utilization (%)
-  query:
-    select: average(provider.cpuUtilization.Average)
-    from: DatastoreSample
-    where: provider='ElastiCacheMemcachedCluster'
-    eventId: entityGuid
-    eventName: entityName
+  queries:
+    aws:
+      select: average(aws.rds.CPUUtilization)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+    awsSample:
+      select: average(provider.cpuUtilization.Average)
+      from: DatastoreSample
+      where: provider='ElastiCacheMemcachedCluster'
+      eventId: entityGuid
+      eventName: entityName
 swapUsageBytes:
   title: Swap usage (bytes)
-  query:
-    select: average(`provider.swapUsage.Average`)
-    from: DatastoreSample
-    where: provider='ElastiCacheMemcachedCluster'
-    eventId: entityGuid
-    eventName: entityName
+  queries:
+    aws:
+      select: average(aws.elasticache.SwapUsage.byMemcachedCluster)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+    awsSample:
+      select: average(`provider.swapUsage.Average`)
+      from: DatastoreSample
+      where: provider='ElastiCacheMemcachedCluster'
+      eventId: entityGuid
+      eventName: entityName
 freeableMemory:
   title: Free memory (bytes)
-  query:
-    select: average(`provider.freeableMemory.Average`)
-    from: DatastoreSample
-    where: provider='ElastiCacheMemcachedCluster'
-    eventId: entityGuid
-    eventName: entityName
+  queries:
+    aws:
+      select: average(aws.elasticache.FreeableMemory.byMemcachedCluster)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+    awsSample:
+      select: average(`provider.freeableMemory.Average`)
+      from: DatastoreSample
+      where: provider='ElastiCacheMemcachedCluster'
+      eventId: entityGuid
+      eventName: entityName
 networkBytesIn:
   title: Bytes in per sec
-  query:
-    select: rate(sum(`provider.networkBytesIn.Sum`), 1 second)
-    from: DatastoreSample
-    where: provider='ElastiCacheMemcachedCluster'
-    eventId: entityGuid
-    eventName: entityName
+  queries:
+    aws:
+      select: rate(sum(aws.elasticache.NetworkBytesIn.byMemcachedCluster), 1 second)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+    awsSample:
+      select: rate(sum(`provider.networkBytesIn.Sum`), 1 second)
+      from: DatastoreSample
+      where: provider='ElastiCacheMemcachedCluster'
+      eventId: entityGuid
+      eventName: entityName
 networkBytesOut:
   title: Bytes out per sec
-  query:
-    select: rate(sum(`provider.networkBytesOut.Sum`), 1 second)
-    from: DatastoreSample
-    where: provider='ElastiCacheMemcachedCluster'
-    eventId: entityGuid
-    eventName: entityName
+  queries:
+    aws:
+      select: rate(sum(aws.elasticache.NetworkBytesOut.byMemcachedCluster), 1 second)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+    awsSample:
+      select: rate(sum(`provider.networkBytesOut.Sum`), 1 second)
+      from: DatastoreSample
+      where: provider='ElastiCacheMemcachedCluster'
+      eventId: entityGuid
+      eventName: entityName

--- a/definitions/infra-awselasticachememcachednode/golden_metrics.yml
+++ b/definitions/infra-awselasticachememcachednode/golden_metrics.yml
@@ -1,48 +1,84 @@
 getThroughput:
   title: Gets per sec
-  query:
-    select: rate(sum(provider.getHits.Sum) + sum(provider.getMisses.Sum), 1 second)
-    from: DatastoreSample
-    where: provider='ElastiCacheMemcachedNode'
-    eventId: entityGuid
-    eventName: entityName
+  queries:
+    aws:
+      select: rate(sum(aws.elasticache.GetHits) + sum(aws.elasticache.GetMisses), 1 second)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+    awsSample:
+      select: rate(sum(provider.getHits.Sum) + sum(provider.getMisses.Sum), 1 second)
+      from: DatastoreSample
+      where: provider='ElastiCacheMemcachedNode'
+      eventId: entityGuid
+      eventName: entityName
 getMisses:
   title: Get hit rate (%)
-  query:
-    select: (sum(provider.getHits.Sum) / (sum(provider.getHits.Sum) + sum(provider.getMisses.Sum))) * 100
-    from: DatastoreSample
-    where: provider='ElastiCacheMemcachedNode'
-    eventId: entityGuid
-    eventName: entityName
+  queries:
+    aws:
+      select: (sum(aws.elasticache.GetHits) / (sum(aws.elasticache.GetHits) + sum(aws.elasticache.GetMisses))) * 100
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+    awsSample:
+      select: (sum(provider.getHits.Sum) / (sum(provider.getHits.Sum) + sum(provider.getMisses.Sum))) * 100
+      from: DatastoreSample
+      where: provider='ElastiCacheMemcachedNode'
+      eventId: entityGuid
+      eventName: entityName
 evictedItems:
   title: Evicted items per sec
-  query:
-    select: rate(sum(`provider.evictions.Sum`), 1 second)
-    from: DatastoreSample
-    where: provider='ElastiCacheMemcachedNode'
-    eventId: entityGuid
-    eventName: entityName
+  queries:
+    aws:
+      select: rate(sum(aws.elasticache.Evictions.byMemcachedNode), 1 second)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+    awsSample:
+      select: rate(sum(`provider.evictions.Sum`), 1 second)
+      from: DatastoreSample
+      where: provider='ElastiCacheMemcachedNode'
+      eventId: entityGuid
+      eventName: entityName
 swapUsage:
   title: Swap Usage
-  query:
-    select: average(`provider.swapUsage.Average`)
-    from: DatastoreSample
-    where: provider='ElastiCacheMemcachedNode'
-    eventId: entityGuid
-    eventName: entityName
+  queries:
+    aws:
+      select: average(aws.elasticache.SwapUsage.byMemcachedCluster)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+    awsSample:
+      select: average(`provider.swapUsage.Average`)
+      from: DatastoreSample
+      where: provider='ElastiCacheMemcachedNode'
+      eventId: entityGuid
+      eventName: entityName
 cpuUtilization:
   title: CPU utilization (%)
-  query:
-    select: average(provider.cpuUtilization.Average)
-    from: DatastoreSample
-    where: provider='ElastiCacheMemcachedNode'
-    eventId: entityGuid
-    eventName: entityName
+  queries:
+    aws:
+      select: average(aws.rds.CPUUtilization)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+    awsSample:
+      select: average(provider.cpuUtilization.Average)
+      from: DatastoreSample
+      where: provider='ElastiCacheMemcachedNode'
+      eventId: entityGuid
+      eventName: entityName
 currentConnections:
   title: Current connections
-  query:
-    select: average(`provider.currConnections.Average`)
-    from: DatastoreSample
-    where: provider='ElastiCacheMemcachedNode'
-    eventId: entityGuid
-    eventName: entityName
+  queries:
+    aws:
+      select: average(aws.elasticache.CurrConnections.byMemcachedNode)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+    awsSample:
+      select: average(`provider.currConnections.Average`)
+      from: DatastoreSample
+      where: provider='ElastiCacheMemcachedNode'
+      eventId: entityGuid
+      eventName: entityName

--- a/definitions/infra-awselasticachememcachednode/golden_metrics.yml
+++ b/definitions/infra-awselasticachememcachednode/golden_metrics.yml
@@ -1,7 +1,7 @@
 getThroughput:
   title: Gets per sec
   query:
-    select: rate(sum(provider.getHits.Sum)+sum(provider.getMisses.Sum), 1 second)
+    select: rate(sum(provider.getHits.Sum) + sum(provider.getMisses.Sum), 1 second)
     from: DatastoreSample
     where: provider='ElastiCacheMemcachedNode'
     eventId: entityGuid
@@ -9,7 +9,7 @@ getThroughput:
 getMisses:
   title: Get hit rate (%)
   query:
-    select: (sum(provider.getHits.Sum)/(sum(provider.getHits.Sum)+sum(provider.getMisses.Sum)))*100
+    select: (sum(provider.getHits.Sum) / (sum(provider.getHits.Sum) + sum(provider.getMisses.Sum))) * 100
     from: DatastoreSample
     where: provider='ElastiCacheMemcachedNode'
     eventId: entityGuid

--- a/definitions/infra-awselasticacherediscluster/golden_metrics.yml
+++ b/definitions/infra-awselasticacherediscluster/golden_metrics.yml
@@ -1,48 +1,84 @@
 cpuUtilization:
   title: CPU utilization (%)
-  query:
-    select: average(provider.cpuUtilization.Average)
-    from: DatastoreSample
-    where: provider='ElastiCacheRedisCluster'
-    eventId: entityGuid
-    eventName: entityName
+  queries:
+    aws:
+      select: average(aws.rds.CPUUtilization)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+    awsSample:
+      select: average(provider.cpuUtilization.Average)
+      from: DatastoreSample
+      where: provider='ElastiCacheRedisCluster'
+      eventId: entityGuid
+      eventName: entityName
 engineCpuUtilization:
   title: Engine CPU utilization (%)
-  query:
-    select: average(provider.engineCpuUtilization.Average)
-    from: DatastoreSample
-    where: provider='ElastiCacheRedisCluster'
-    eventId: entityGuid
-    eventName: entityName
+  queries:
+    aws:
+      select: average(aws.elasticache.EngineCPUUtilization.byRedisCluster)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+    awsSample:
+      select: average(provider.engineCpuUtilization.Average)
+      from: DatastoreSample
+      where: provider='ElastiCacheRedisCluster'
+      eventId: entityGuid
+      eventName: entityName
 swapUsageBytes:
   title: Swap usage (bytes)
-  query:
-    select: average(`provider.swapUsage.Average`)
-    from: DatastoreSample
-    where: provider='ElastiCacheRedisCluster'
-    eventId: entityGuid
-    eventName: entityName
+  queries:
+    aws:
+      select: average(aws.elasticache.SwapUsage.byMemcachedCluster)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+    awsSample:
+      select: average(`provider.swapUsage.Average`)
+      from: DatastoreSample
+      where: provider='ElastiCacheRedisCluster'
+      eventId: entityGuid
+      eventName: entityName
 freeableMemory:
   title: Free memory (bytes)
-  query:
-    select: average(`provider.freeableMemory.Average`)
-    from: DatastoreSample
-    where: provider='ElastiCacheRedisCluster'
-    eventId: entityGuid
-    eventName: entityName
+  queries:
+    aws:
+      select: average(aws.elasticache.FreeableMemory.byMemcachedCluster)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+    awsSample:
+      select: average(`provider.freeableMemory.Average`)
+      from: DatastoreSample
+      where: provider='ElastiCacheRedisCluster'
+      eventId: entityGuid
+      eventName: entityName
 networkBytesIn:
   title: Bytes in per sec
-  query:
-    select: rate(sum(`provider.networkBytesIn.Sum`), 1 second)
-    from: DatastoreSample
-    where: provider='ElastiCacheRedisCluster'
-    eventId: entityGuid
-    eventName: entityName
+  queries:
+    aws:
+      select: rate(sum(aws.elasticache.NetworkBytesIn.byMemcachedCluster), 1 second)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+    awsSample:
+      select: rate(sum(`provider.networkBytesIn.Sum`), 1 second)
+      from: DatastoreSample
+      where: provider='ElastiCacheRedisCluster'
+      eventId: entityGuid
+      eventName: entityName
 networkBytesOut:
   title: Bytes out per sec
-  query:
-    select: rate(sum(`provider.networkBytesOut.Sum`), 1 second)
-    from: DatastoreSample
-    where: provider='ElastiCacheRedisCluster'
-    eventId: entityGuid
-    eventName: entityName
+  queries:
+    aws:
+      select: rate(sum(aws.elasticache.NetworkBytesOut.byMemcachedCluster), 1 second)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+    awsSample:
+      select: rate(sum(`provider.networkBytesOut.Sum`), 1 second)
+      from: DatastoreSample
+      where: provider='ElastiCacheRedisCluster'
+      eventId: entityGuid
+      eventName: entityName

--- a/definitions/infra-awselasticacheredisnode/golden_metrics.yml
+++ b/definitions/infra-awselasticacheredisnode/golden_metrics.yml
@@ -1,48 +1,84 @@
 readThroughput:
   title: Reads per sec
-  query:
-    select: rate(sum(provider.cacheHits.Sum)+sum(provider.cacheMisses.Sum), 1 second)
-    from: DatastoreSample
-    where: provider='ElastiCacheRedisNode'
-    eventId: entityGuid
-    eventName: entityName
+  queries:
+    aws:
+      select: rate(sum(aws.elasticache.CacheHits) + sum(aws.elasticache.CacheMisses), 1 second)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+    awsSample:
+      select: rate(sum(provider.cacheHits.Sum)+sum(provider.cacheMisses.Sum), 1 second)
+      from: DatastoreSample
+      where: provider='ElastiCacheRedisNode'
+      eventId: entityGuid
+      eventName: entityName
 cacheHitRate:
   title: Cache hit rate (%)
-  query:
-    select: (sum(provider.cacheHits.Sum)/(sum(provider.cacheHits.Sum)+sum(provider.cacheMisses.Sum)))*100
-    from: DatastoreSample
-    where: provider='ElastiCacheRedisNode'
-    eventId: entityGuid
-    eventName: entityName
+  queries:
+    aws:
+      select: 100 * sum(aws.elasticache.CacheHits) / (sum(aws.elasticache.CacheHits) + sum(aws.elasticache.CacheMisses))
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+    awsSample:
+      select: (sum(provider.cacheHits.Sum)/(sum(provider.cacheHits.Sum)+sum(provider.cacheMisses.Sum)))*100
+      from: DatastoreSample
+      where: provider='ElastiCacheRedisNode'
+      eventId: entityGuid
+      eventName: entityName
 evictedItems:
   title: Evicted items per sec
-  query:
-    select: rate(sum(`provider.evictions.Sum`), 1 second)
-    from: DatastoreSample
-    where: provider='ElastiCacheRedisNode'
-    eventId: entityGuid
-    eventName: entityName
+  queries:
+    aws:
+      select: rate(sum(aws.elasticache.Evictions.byMemcachedNode), 1 second)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+    awsSample:
+      select: rate(sum(`provider.evictions.Sum`), 1 second)
+      from: DatastoreSample
+      where: provider='ElastiCacheRedisNode'
+      eventId: entityGuid
+      eventName: entityName
 swapUsage:
   title: Swap Usage
-  query:
-    select: average(`provider.swapUsage.Average`)
-    from: DatastoreSample
-    where: provider='ElastiCacheRedisNode'
-    eventId: entityGuid
-    eventName: entityName
+  queries:
+    aws:
+      select: average(aws.elasticache.SwapUsage.byMemcachedCluster)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+    awsSample:
+      select: average(`provider.swapUsage.Average`)
+      from: DatastoreSample
+      where: provider='ElastiCacheRedisNode'
+      eventId: entityGuid
+      eventName: entityName
 cpuUtilization:
   title: CPU utilization (%)
-  query:
-    select: average(provider.cpuUtilization.Average)
-    from: DatastoreSample
-    where: provider='ElastiCacheRedisNode'
-    eventId: entityGuid
-    eventName: entityName
+  queries:
+    aws:
+      select: average(aws.rds.CPUUtilization)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+    awsSample:
+      select: average(provider.cpuUtilization.Average)
+      from: DatastoreSample
+      where: provider='ElastiCacheRedisNode'
+      eventId: entityGuid
+      eventName: entityName
 currentConnections:
   title: Current connections
-  query:
-    select: average(`provider.currConnections.Average`)
-    from: DatastoreSample
-    where: provider='ElastiCacheRedisNode'
-    eventId: entityGuid
-    eventName: entityName
+  queries:
+    aws:
+      select: average(aws.elasticache.CurrConnections.byMemcachedNode)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+    awsSample:
+      select: average(`provider.currConnections.Average`)
+      from: DatastoreSample
+      where: provider='ElastiCacheRedisNode'
+      eventId: entityGuid
+      eventName: entityName

--- a/definitions/infra-awselasticbeanstalkenvironment/golden_metrics.yml
+++ b/definitions/infra-awselasticbeanstalkenvironment/golden_metrics.yml
@@ -1,16 +1,26 @@
 requests:
-  query:
-    eventId: entityGuid
-    select: sum(`provider.applicationRequestsTotal.Sum`)
-    from: ElasticBeanstalkEnvironmentSample
-    eventName: entityName
-  unit: COUNT
   title: Requests
+  queries:
+    aws:
+      select: sum(aws.elasticbeanstalk.ApplicationRequestsTotal.byEnvironment)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+    awsSample:
+      select: sum(`provider.applicationRequestsTotal.Sum`)
+      from: ElasticBeanstalkEnvironmentSample
+      eventId: entityGuid
+      eventName: entityName
 latency:
-  query:
-    eventId: entityGuid
-    select: average(`provider.applicationLatencyP99.9.Average`)
-    from: ElasticBeanstalkEnvironmentSample
-    eventName: entityName
-  unit: SECONDS
   title: Latency
+  queries:
+    aws:
+      select: average(aws.elasticbeanstalk.ApplicationLatencyP99.9.byEnvironment)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+    awsSample:
+      select: average(`provider.applicationLatencyP99.9.Average`)
+      from: ElasticBeanstalkEnvironmentSample
+      eventId: entityGuid
+      eventName: entityName

--- a/definitions/infra-awselasticbeanstalkenvironment/golden_metrics.yml
+++ b/definitions/infra-awselasticbeanstalkenvironment/golden_metrics.yml
@@ -9,7 +9,7 @@ requests:
 latency:
   query:
     eventId: entityGuid
-    select: (average(`provider.applicationLatencyP99.9.Average`) * 1000) / 1000
+    select: average(`provider.applicationLatencyP99.9.Average`)
     from: ElasticBeanstalkEnvironmentSample
     eventName: entityName
   unit: SECONDS

--- a/definitions/infra-awselasticbeanstalkinstance/golden_metrics.yml
+++ b/definitions/infra-awselasticbeanstalkinstance/golden_metrics.yml
@@ -8,7 +8,7 @@ requests:
 latency:
   query:
     eventId: entityGuid
-    select: (average(`provider.applicationLatencyP99.9.Average`) * 1000) / 1000
+    select: average(`provider.applicationLatencyP99.9.Average`)
     from: ElasticBeanstalkInstanceSample
   unit: SECONDS
   title: Latency

--- a/definitions/infra-awselasticbeanstalkinstance/golden_metrics.yml
+++ b/definitions/infra-awselasticbeanstalkinstance/golden_metrics.yml
@@ -1,14 +1,26 @@
 requests:
-  query:
-    eventId: entityGuid
-    select: sum(`provider.applicationRequestsTotal.Sum`)
-    from: ElasticBeanstalkInstanceSample
-  unit: COUNT
   title: Requests
+  queries:
+    aws:
+      select: sum(aws.elasticbeanstalk.ApplicationRequestsTotal.byInstance)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+    awsSample:
+      select: sum(`provider.applicationRequestsTotal.Sum`)
+      from: ElasticBeanstalkInstanceSample
+      eventId: entityGuid
+      eventName: entityName
 latency:
-  query:
-    eventId: entityGuid
-    select: average(`provider.applicationLatencyP99.9.Average`)
-    from: ElasticBeanstalkInstanceSample
-  unit: SECONDS
   title: Latency
+  queries:
+    aws:
+      select: average(aws.elasticbeanstalk.ApplicationLatencyP99.9.byInstance)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+    awsSample:
+      select: average(`provider.applicationLatencyP99.9.Average`)
+      from: ElasticBeanstalkInstanceSample
+      eventId: entityGuid
+      eventName: entityName

--- a/definitions/infra-awselasticmapreducecluster/golden_metrics.yml
+++ b/definitions/infra-awselasticmapreducecluster/golden_metrics.yml
@@ -1,27 +1,42 @@
 availableMemoryBytes:
   title: Available memory
-  query:
-    select: average(provider.memoryAvailableBytes.Average)
-    from: ElasticMapReduceClusterSample
-    where: provider='ElasticMapReduceCluster'
-    eventId: entityGuid
-    eventName: entityName
-  unit: BYTES
+  queries:
+    aws:
+      select: average(aws.elasticmapreduce.MemoryAvailableMB)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+    awsSample:
+      select: average(provider.memoryAvailableBytes.Average)
+      from: ElasticMapReduceClusterSample
+      where: provider='ElasticMapReduceCluster'
+      eventId: entityGuid
+      eventName: entityName
 completedApplications:
   title: Completed applications
-  query:
-    select: rate(sum(provider.appsCompleted.Sum), 1 minute)
-    from: ElasticMapReduceClusterSample
-    where: provider='ElasticMapReduceCluster'
-    eventId: entityGuid
-    eventName: entityName
-  unit: COUNT
+  queries:
+    aws:
+      select: rate(sum(aws.elasticmapreduce.AppsCompleted), 1 minute)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+    awsSample:
+      select: rate(sum(provider.appsCompleted.Sum), 1 minute)
+      from: ElasticMapReduceClusterSample
+      where: provider='ElasticMapReduceCluster'
+      eventId: entityGuid
+      eventName: entityName
 failedApplications:
   title: Failed applications
-  query:
-    select: rate(sum(provider.appsFailed.Sum), 1 minute)
-    from: ElasticMapReduceClusterSample
-    where: provider='ElasticMapReduceCluster'
-    eventId: entityGuid
-    eventName: entityName
-  unit: COUNT
+  queries:
+    aws:
+      select: rate(sum(aws.elasticmapreduce.AppsFailed), 1 minute)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+    awsSample:
+      select: rate(sum(provider.appsFailed.Sum), 1 minute)
+      from: ElasticMapReduceClusterSample
+      where: provider='ElasticMapReduceCluster'
+      eventId: entityGuid
+      eventName: entityName

--- a/definitions/infra-awselasticsearchcluster/golden_metrics.yml
+++ b/definitions/infra-awselasticsearchcluster/golden_metrics.yml
@@ -1,48 +1,84 @@
 searchRateOpsMin:
   title: Search rate (reqs/min)
-  query:
-    select: average(provider.SearchRate.Average)
-    from: DatastoreSample
-    where: provider='ElasticsearchCluster'
-    eventId: entityGuid
-    eventName: entityName
+  queries:
+    aws:
+      select: average(aws.es.SearchRate.byCluster)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+    awsSample:
+      select: average(provider.SearchRate.Average)
+      from: DatastoreSample
+      where: provider='ElasticsearchCluster'
+      eventId: entityGuid
+      eventName: entityName
 indexingRateReqsMin:
   title: Indexing rate (reqs/min)
-  query:
-    select: average(provider.IndexingRate.Average)
-    from: DatastoreSample
-    where: provider='ElasticsearchCluster'
-    eventId: entityGuid
-    eventName: entityName
+  queries:
+    aws:
+      select: average(aws.es.IndexingRate.byCluster)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+    awsSample:
+      select: average(provider.IndexingRate.Average)
+      from: DatastoreSample
+      where: provider='ElasticsearchCluster'
+      eventId: entityGuid
+      eventName: entityName
 searchLatencyMs:
   title: Search latency (ms)
-  query:
-    select: average(provider.SearchLatency.Average)
-    from: DatastoreSample
-    where: provider='ElasticsearchCluster'
-    eventId: entityGuid
-    eventName: entityName
+  queries:
+    aws:
+      select: average(aws.es.SearchLatency.byCluster)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+    awsSample:
+      select: average(provider.SearchLatency.Average)
+      from: DatastoreSample
+      where: provider='ElasticsearchCluster'
+      eventId: entityGuid
+      eventName: entityName
 indexingLatencyMs:
   title: Indexing latency (ms)
-  query:
-    select: average(provider.IndexingLatency.Average)
-    from: DatastoreSample
-    where: provider='ElasticsearchCluster'
-    eventId: entityGuid
-    eventName: entityName
+  queries:
+    aws:
+      select: average(aws.es.IndexingLatency.byCluster)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+    awsSample:
+      select: average(provider.IndexingLatency.Average)
+      from: DatastoreSample
+      where: provider='ElasticsearchCluster'
+      eventId: entityGuid
+      eventName: entityName
 cpuUtilization:
   title: CPU Utilization (%)
-  query:
-    select: average(`provider.CPUUtilization.Average`)
-    from: DatastoreSample
-    where: provider='ElasticsearchCluster'
-    eventId: entityGuid
-    eventName: entityName
+  queries:
+    aws:
+      select: average(aws.es.CPUUtilization.byCluster)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+    awsSample:
+      select: average(`provider.CPUUtilization.Average`)
+      from: DatastoreSample
+      where: provider='ElasticsearchCluster'
+      eventId: entityGuid
+      eventName: entityName
 jvmMemoryPressure:
   title: JVM memory pressure (%)
-  query:
-    select: max(`provider.JVMMemoryPressure.Maximum`)
-    from: DatastoreSample
-    where: provider='ElasticsearchCluster'
-    eventId: entityGuid
-    eventName: entityName
+  queries:
+    aws:
+      select: max(aws.es.JVMMemoryPressure.byCluster)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+    awsSample:
+      select: max(`provider.JVMMemoryPressure.Maximum`)
+      from: DatastoreSample
+      where: provider='ElasticsearchCluster'
+      eventId: entityGuid
+      eventName: entityName

--- a/definitions/infra-awselasticsearchnode/golden_metrics.yml
+++ b/definitions/infra-awselasticsearchnode/golden_metrics.yml
@@ -1,48 +1,84 @@
 searchRateOpsMin:
   title: Search rate (reqs/min)
-  query:
-    select: average(provider.SearchRate.Average)
-    from: DatastoreSample
-    where: provider='ElasticsearchNode'
-    eventId: entityGuid
-    eventName: entityName
+  queries:
+    aws:
+      select: average(aws.es.SearchRate.byCluster)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+    awsSample:
+      select: average(provider.SearchRate.Average)
+      from: DatastoreSample
+      where: provider='ElasticsearchNode'
+      eventId: entityGuid
+      eventName: entityName
 indexingRateReqsMin:
   title: Indexing rate (reqs/min)
-  query:
-    select: average(provider.IndexingRate.Average)
-    from: DatastoreSample
-    where: provider='ElasticsearchNode'
-    eventId: entityGuid
-    eventName: entityName
+  queries:
+    aws:
+      select: average(aws.es.IndexingRate.byCluster)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+    awsSample:
+      select: average(provider.IndexingRate.Average)
+      from: DatastoreSample
+      where: provider='ElasticsearchNode'
+      eventId: entityGuid
+      eventName: entityName
 searchLatencyMs:
   title: Search latency (ms)
-  query:
-    select: average(provider.SearchLatency.Average)
-    from: DatastoreSample
-    where: provider='ElasticsearchNode'
-    eventId: entityGuid
-    eventName: entityName
+  queries:
+    aws:
+      select: average(aws.es.SearchLatency.byCluster)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+    awsSample:
+      select: average(provider.SearchLatency.Average)
+      from: DatastoreSample
+      where: provider='ElasticsearchNode'
+      eventId: entityGuid
+      eventName: entityName
 indexingLatencyMs:
   title: Indexing latency (ms)
-  query:
-    select: average(provider.IndexingLatency.Average)
-    from: DatastoreSample
-    where: provider='ElasticsearchNode'
-    eventId: entityGuid
-    eventName: entityName
+  queries:
+    aws:
+      select: average(aws.es.IndexingLatency.byCluster)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+    awsSample:
+      select: average(provider.IndexingLatency.Average)
+      from: DatastoreSample
+      where: provider='ElasticsearchNode'
+      eventId: entityGuid
+      eventName: entityName
 cpuUtilization:
   title: Max CPU Utilization (%)
-  query:
-    select: max(`provider.CPUUtilization.Maximum`)
-    from: DatastoreSample
-    where: provider='ElasticsearchNode'
-    eventId: entityGuid
-    eventName: entityName
+  queries:
+    aws:
+      select: max(aws.es.CPUUtilization.byCluster)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+    awsSample:
+      select: max(`provider.CPUUtilization.Maximum`)
+      from: DatastoreSample
+      where: provider='ElasticsearchNode'
+      eventId: entityGuid
+      eventName: entityName
 jvmMemoryPressure:
   title: Max JVM memory pressure (%)
-  query:
-    select: max(`provider.JVMMemoryPressure.Maximum`)
-    from: DatastoreSample
-    where: provider='ElasticsearchNode'
-    eventId: entityGuid
-    eventName: entityName
+  queries:
+    aws:
+      select: max(aws.es.JVMMemoryPressure.byCluster)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+    awsSample:
+      select: max(`provider.JVMMemoryPressure.Maximum`)
+      from: DatastoreSample
+      where: provider='ElasticsearchNode'
+      eventId: entityGuid
+      eventName: entityName

--- a/definitions/infra-awselb/golden_metrics.yml
+++ b/definitions/infra-awselb/golden_metrics.yml
@@ -22,22 +22,6 @@ errorRate:
     where: provider='Elb'
     eventId: entityGuid
     eventName: entityName
-latencyP99:
-  title: P99 Latency (s)
-  query:
-    select: average(provider.latency.p99)
-    from: LoadBalancerSample
-    where: provider='Elb'
-    eventId: entityGuid
-    eventName: entityName
-latencyP90:
-  title: P90 Latency (s)
-  query:
-    select: average(provider.latency.p90)
-    from: LoadBalancerSample
-    where: provider='Elb'
-    eventId: entityGuid
-    eventName: entityName
 unhealthyHosts:
   title: Unhealthy hosts
   query:

--- a/definitions/infra-awselb/golden_metrics.yml
+++ b/definitions/infra-awselb/golden_metrics.yml
@@ -1,32 +1,56 @@
 requests:
   title: Requests per min
-  query:
-    select: rate(sum(provider.requestCount.Sum), 1 minute)
-    from: LoadBalancerSample
-    where: provider='Elb'
-    eventId: entityGuid
-    eventName: entityName
+  queries:
+    aws:
+      select: rate(sum(aws.elb.RequestCount), 1 minute)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+    awsSample:
+      select: rate(sum(provider.requestCount.Sum), 1 minute)
+      from: LoadBalancerSample
+      where: provider='Elb'
+      eventId: entityGuid
+      eventName: entityName
 latency:
   title: Latency (s)
-  query:
-    select: average(provider.latency.Average)
-    from: LoadBalancerSample
-    where: provider='Elb'
-    eventId: entityGuid
-    eventName: entityName
+  queries:
+    aws:
+      select: average(aws.elb.Latency)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+    awsSample:
+      select: average(provider.latency.Average)
+      from: LoadBalancerSample
+      where: provider='Elb'
+      eventId: entityGuid
+      eventName: entityName
 errorRate:
   title: Error Rate
-  query:
-    select: rate(sum(provider.backendConnectionErrors.Sum), 1 minute)
-    from: LoadBalancerSample
-    where: provider='Elb'
-    eventId: entityGuid
-    eventName: entityName
+  queries:
+    aws:
+      select: rate(sum(aws.elb.BackendConnectionErrors), 1 minute)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+    awsSample:
+      select: rate(sum(provider.backendConnectionErrors.Sum), 1 minute)
+      from: LoadBalancerSample
+      where: provider='Elb'
+      eventId: entityGuid
+      eventName: entityName
 unhealthyHosts:
   title: Unhealthy hosts
-  query:
-    select: average(`provider.unhealthyHostCount.Average`)
-    from: LoadBalancerSample
-    where: provider='Elb'
-    eventId: entityGuid
-    eventName: entityName
+  queries:
+    aws:
+      select: average(aws.elb.UnhealthyHostCount)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+    awsSample:
+      select: average(`provider.unhealthyHostCount.Average`)
+      from: LoadBalancerSample
+      where: provider='Elb'
+      eventId: entityGuid
+      eventName: entityName

--- a/definitions/infra-awsfsxwindowsfileserver/golden_metrics.yml
+++ b/definitions/infra-awsfsxwindowsfileserver/golden_metrics.yml
@@ -1,28 +1,52 @@
 fileSystemReadOperationsBytes:
   title: File system read operations (bytes)
-  query:
-    select: average(provider.dataReadBytes.Average)
-    from: AwsFsxWindowsFileServerSample
-    eventId: entityGuid
-    eventName: entityName
+  queries:
+    aws:
+      select: average(aws.fsx.DataReadBytes)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+    awsSample:
+      select: average(provider.dataReadBytes.Average)
+      from: AwsFsxWindowsFileServerSample
+      eventId: entityGuid
+      eventName: entityName
 fileSystemWriteOperationsBytes:
   title: File system write operations (bytes)
-  query:
-    select: average(provider.dataWriteBytes.Average)
-    from: AwsFsxWindowsFileServerSample
-    eventId: entityGuid
-    eventName: entityName
+  queries:
+    aws:
+      select: average(aws.fsx.DataWriteBytes)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+    awsSample:
+      select: average(provider.dataWriteBytes.Average)
+      from: AwsFsxWindowsFileServerSample
+      eventId: entityGuid
+      eventName: entityName
 readOperations:
   title: Read operations
-  query:
-    select: average(provider.dataReadOperations.Average)
-    from: AwsFsxWindowsFileServerSample
-    eventId: entityGuid
-    eventName: entityName
+  queries:
+    aws:
+      select: average(aws.fsx.DataReadOperations)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+    awsSample:
+      select: average(provider.dataReadOperations.Average)
+      from: AwsFsxWindowsFileServerSample
+      eventId: entityGuid
+      eventName: entityName
 writeOperations:
   title: Write operations
-  query:
-    select: average(provider.dataWriteOperations.Average)
-    from: AwsFsxWindowsFileServerSample
-    eventId: entityGuid
-    eventName: entityName
+  queries:
+    aws:
+      select: average(aws.fsx.DataWriteOperations)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+    awsSample:
+      select: average(provider.dataWriteOperations.Average)
+      from: AwsFsxWindowsFileServerSample
+      eventId: entityGuid
+      eventName: entityName

--- a/definitions/infra-awsfsxwindowsfileserver/golden_metrics.yml
+++ b/definitions/infra-awsfsxwindowsfileserver/golden_metrics.yml
@@ -1,28 +1,28 @@
 fileSystemReadOperationsBytes:
   title: File system read operations (bytes)
   query:
-    select: average(dataReadBytes)
+    select: average(provider.dataReadBytes.Average)
     from: AwsFsxWindowsFileServerSample
     eventId: entityGuid
     eventName: entityName
 fileSystemWriteOperationsBytes:
   title: File system write operations (bytes)
   query:
-    select: average(dataWriteBytes)
+    select: average(provider.dataWriteBytes.Average)
     from: AwsFsxWindowsFileServerSample
     eventId: entityGuid
     eventName: entityName
 readOperations:
   title: Read operations
   query:
-    select: average(dataReadOperations)
+    select: average(provider.dataReadOperations.Average)
     from: AwsFsxWindowsFileServerSample
     eventId: entityGuid
     eventName: entityName
 writeOperations:
   title: Write operations
   query:
-    select: average(dataWriteOperations)
+    select: average(provider.dataWriteOperations.Average)
     from: AwsFsxWindowsFileServerSample
     eventId: entityGuid
     eventName: entityName

--- a/definitions/infra-awskinesisdeliverystream/golden_metrics.yml
+++ b/definitions/infra-awskinesisdeliverystream/golden_metrics.yml
@@ -1,34 +1,56 @@
 putThroughput:
   title: Bytes in per sec
-  query:
-    select: rate(sum(provider.incomingBytes.Sum), 1 second)
-    from: QueueSample
-    where: provider='KinesisDeliveryStream'
-    eventId: entityGuid
-    eventName: entityName
+  queries:
+    aws:
+      select: rate(sum(aws.kinesis.IncomingBytes.byStream), 1 second)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+    awsSample:
+      select: rate(sum(provider.incomingBytes.Sum), 1 second)
+      from: QueueSample
+      where: provider='KinesisDeliveryStream'
+      eventId: entityGuid
+      eventName: entityName
 getThroughput:
   title: Bytes out per sec
-  query:
-    select: rate((sum(`provider.deliveryToElasticsearchBytes.Sum`) + sum(`provider.deliveryToS3Bytes.Sum`)
-      + sum(`provider.deliveryToRedshiftBytes.Sum`)), 1 second)
-    from: QueueSample
-    where: provider='KinesisDeliveryStream'
-    eventId: entityGuid
-    eventName: entityName
+  queries:
+    aws:
+      select: rate(sum(aws.firehose.DeliveryToElasticsearch.Bytes) + sum(aws.firehose.DeliveryToS3.Bytes) + sum(aws.firehose.DeliveryToRedshift.Bytes), 1 second)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+    awsSample:
+      select: rate((sum(`provider.deliveryToElasticsearchBytes.Sum`) + sum(`provider.deliveryToS3Bytes.Sum`) + sum(`provider.deliveryToRedshiftBytes.Sum`)), 1 second)
+      from: QueueSample
+      where: provider='KinesisDeliveryStream'
+      eventId: entityGuid
+      eventName: entityName
 putRecordThroughput:
   title: Records in per sec
-  query:
-    select: rate(sum(provider.incomingRecords.Sum), 1 second)
-    from: QueueSample
-    where: provider='KinesisDeliveryStream'
-    eventId: entityGuid
-    eventName: entityName
+  queries:
+    aws:
+      select: rate(sum(aws.kinesis.IncomingRecords.byStream), 1 second)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+    awsSample:
+      select: rate(sum(provider.incomingRecords.Sum), 1 second)
+      from: QueueSample
+      where: provider='KinesisDeliveryStream'
+      eventId: entityGuid
+      eventName: entityName
 getRecordsThroughput:
   title: Records out per sec
-  query:
-    select: rate((sum(`provider.deliveryToElasticsearchRecords.Sum`) + sum(`provider.deliveryToS3Records.Sum`)
-      + sum(`provider.deliveryToRedshiftRecords.Sum`)), 1 second)
-    from: QueueSample
-    where: provider='KinesisDeliveryStream'
-    eventId: entityGuid
-    eventName: entityName
+  queries:
+    aws:
+      select: rate(sum(aws.firehose.DeliveryToElasticsearch.Records) + sum(aws.firehose.DeliveryToS3.Records) + sum(aws.firehose.DeliveryToRedshift.Records), 1 second)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+    awsSample:
+      select: rate((sum(`provider.deliveryToElasticsearchRecords.Sum`) + sum(`provider.deliveryToS3Records.Sum`) + sum(`provider.deliveryToRedshiftRecords.Sum`)), 1 second)
+      from: QueueSample
+      where: provider='KinesisDeliveryStream'
+      eventId: entityGuid
+      eventName: entityName

--- a/definitions/infra-awskinesisstream/golden_metrics.yml
+++ b/definitions/infra-awskinesisstream/golden_metrics.yml
@@ -1,48 +1,84 @@
 putThroughput:
   title: Bytes in per sec
-  query:
-    select: rate(sum(provider.incomingBytes.Sum), 1 second)
-    from: QueueSample
-    where: provider='KinesisStream'
-    eventId: entityGuid
-    eventName: entityName
+  queries:
+    aws:
+      select: rate(sum(aws.kinesis.IncomingBytes.byStream), 1 second)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+    awsSample:
+      select: rate(sum(provider.incomingBytes.Sum), 1 second)
+      from: QueueSample
+      where: provider='KinesisStream'
+      eventId: entityGuid
+      eventName: entityName
 getThroughput:
   title: Bytes out per sec
-  query:
-    select: rate(sum(provider.getRecordsBytes.Sum), 1 second)
-    from: QueueSample
-    where: provider='KinesisStream'
-    eventId: entityGuid
-    eventName: entityName
+  queries:
+    aws:
+      select: rate(sum(aws.kinesis.GetRecords.Bytes), 1 second)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+    awsSample:
+      select: rate(sum(provider.getRecordsBytes.Sum), 1 second)
+      from: QueueSample
+      where: provider='KinesisStream'
+      eventId: entityGuid
+      eventName: entityName
 putRecordThroughput:
   title: Put records per sec
-  query:
-    select: rate(sum(provider.incomingRecords.Sum), 1 second)
-    from: QueueSample
-    where: provider='KinesisStream'
-    eventId: entityGuid
-    eventName: entityName
+  queries:
+    aws:
+      select: rate(sum(aws.kinesis.IncomingRecords.byStream), 1 second)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+    awsSample:
+      select: rate(sum(provider.incomingRecords.Sum), 1 second)
+      from: QueueSample
+      where: provider='KinesisStream'
+      eventId: entityGuid
+      eventName: entityName
 getRecordsThroughput:
   title: Get records per sec
-  query:
-    select: rate(sum(provider.getRecordsRecords.Sum), 1 second)
-    from: QueueSample
-    where: provider='KinesisStream'
-    eventId: entityGuid
-    eventName: entityName
+  queries:
+    aws:
+      select: rate(sum(aws.kinesis.GetRecords.Records), 1 second)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+    awsSample:
+      select: rate(sum(provider.getRecordsRecords.Sum), 1 second)
+      from: QueueSample
+      where: provider='KinesisStream'
+      eventId: entityGuid
+      eventName: entityName
 putrecordsCallsThrottled:
   title: Puts throttled per second
-  query:
-    select: rate(sum(provider.writeProvisionedThroughputExceeded.Sum), 1 second)
-    from: QueueSample
-    where: provider='KinesisStream'
-    eventId: entityGuid
-    eventName: entityName
+  queries:
+    aws:
+      select: rate(sum(aws.kinesis.WriteProvisionedThroughputExceeded.byStream), 1 second)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+    awsSample:
+      select: rate(sum(provider.writeProvisionedThroughputExceeded.Sum), 1 second)
+      from: QueueSample
+      where: provider='KinesisStream'
+      eventId: entityGuid
+      eventName: entityName
 getrecordsCallsThrottled:
   title: Gets throttled per second
-  query:
-    select: rate(sum(provider.readProvisionedThroughputExceeded.Sum), 1 second)
-    from: QueueSample
-    where: provider='KinesisStream'
-    eventId: entityGuid
-    eventName: entityName
+  queries:
+    aws:
+      select: rate(sum(aws.kinesis.ReadProvisionedThroughputExceeded.byStream), 1 second)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+    awsSample:
+      select: rate(sum(provider.readProvisionedThroughputExceeded.Sum), 1 second)
+      from: QueueSample
+      where: provider='KinesisStream'
+      eventId: entityGuid
+      eventName: entityName

--- a/definitions/infra-awskinesisstreamshard/golden_metrics.yml
+++ b/definitions/infra-awskinesisstreamshard/golden_metrics.yml
@@ -1,48 +1,84 @@
 putThroughput:
   title: Bytes in per sec
-  query:
-    select: rate(sum(provider.incomingBytes.Sum), 1 second)
-    from: QueueSample
-    where: provider='KinesisStreamShard'
-    eventId: entityGuid
-    eventName: entityName
+  queries:
+    aws:
+      select: rate(sum(aws.kinesis.IncomingBytes.byStream), 1 second)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+    awsSample:
+      select: rate(sum(provider.incomingBytes.Sum), 1 second)
+      from: QueueSample
+      where: provider='KinesisStreamShard'
+      eventId: entityGuid
+      eventName: entityName
 getThroughput:
   title: Bytes out per sec
-  query:
-    select: rate(sum(provider.outgoingBytes.Sum), 1 second)
-    from: QueueSample
-    where: provider='KinesisStreamShard'
-    eventId: entityGuid
-    eventName: entityName
+  queries:
+    aws:
+      select: rate(sum(aws.kinesis.OutgoingBytes), 1 second)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+    awsSample:
+      select: rate(sum(provider.outgoingBytes.Sum), 1 second)
+      from: QueueSample
+      where: provider='KinesisStreamShard'
+      eventId: entityGuid
+      eventName: entityName
 putRecordThroughput:
   title: Put records per sec
-  query:
-    select: rate(sum(provider.incomingRecords.Sum), 1 second)
-    from: QueueSample
-    where: provider='KinesisStreamShard'
-    eventId: entityGuid
-    eventName: entityName
+  queries:
+    aws:
+      select: rate(sum(aws.kinesis.IncomingRecords.byStream), 1 second)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+    awsSample:
+      select: rate(sum(provider.incomingRecords.Sum), 1 second)
+      from: QueueSample
+      where: provider='KinesisStreamShard'
+      eventId: entityGuid
+      eventName: entityName
 getRecordsThroughput:
   title: Get records per sec
-  query:
-    select: rate(sum(provider.outgoingRecords.Sum), 1 second)
-    from: QueueSample
-    where: provider='KinesisStreamShard'
-    eventId: entityGuid
-    eventName: entityName
+  queries:
+    aws:
+      select: rate(sum(aws.kinesis.OutgoingRecords), 1 second)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+    awsSample:
+      select: rate(sum(provider.outgoingRecords.Sum), 1 second)
+      from: QueueSample
+      where: provider='KinesisStreamShard'
+      eventId: entityGuid
+      eventName: entityName
 putrecordsCallsThrottled:
   title: Puts throttled per sec
-  query:
-    select: rate(sum(provider.writeProvisionedThroughputExceeded.Sum), 1 second)
-    from: QueueSample
-    where: provider='KinesisStreamShard'
-    eventId: entityGuid
-    eventName: entityName
+  queries:
+    aws:
+      select: rate(sum(aws.kinesis.WriteProvisionedThroughputExceeded.byStream), 1 second)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+    awsSample:
+      select: rate(sum(provider.writeProvisionedThroughputExceeded.Sum), 1 second)
+      from: QueueSample
+      where: provider='KinesisStreamShard'
+      eventId: entityGuid
+      eventName: entityName
 getrecordsCallsThrottled:
   title: Gets throttled per sec
-  query:
-    select: rate(sum(provider.readProvisionedThroughputExceeded.Sum), 1 second)
-    from: QueueSample
-    where: provider='KinesisStreamShard'
-    eventId: entityGuid
-    eventName: entityName
+  queries:
+    aws:
+      select: rate(sum(aws.kinesis.ReadProvisionedThroughputExceeded.byStream), 1 second)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+    awsSample:
+      select: rate(sum(provider.readProvisionedThroughputExceeded.Sum), 1 second)
+      from: QueueSample
+      where: provider='KinesisStreamShard'
+      eventId: entityGuid
+      eventName: entityName

--- a/definitions/infra-awslambdafunction/golden_metrics.yml
+++ b/definitions/infra-awslambdafunction/golden_metrics.yml
@@ -1,32 +1,56 @@
 errorRate:
   title: Error rate %
-  query:
-    select: sum(provider.errors.Sum) * 100 / sum(provider.invocations.Sum)
-    from: ServerlessSample
-    where: provider='LambdaFunction'
-    eventId: entityGuid
-    eventName: entityName
+  queries:
+    aws:
+      select: sum(aws.lambda.Errors.byFunction) * 100 / sum(aws.lambda.Invocations.byFunction)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+    awsSample:
+      select: sum(provider.errors.Sum) * 100 / sum(provider.invocations.Sum)
+      from: ServerlessSample
+      where: provider='LambdaFunction'
+      eventId: entityGuid
+      eventName: entityName
 totalInvocations:
   title: Total Invocations
-  query:
-    select: rate(sum(provider.invocations.Sum),1 minute)
-    from: ServerlessSample
-    where: provider='LambdaFunction'
-    eventId: entityGuid
-    eventName: entityName
+  queries:
+    aws:
+      select: rate(sum(aws.lambda.Invocations.byFunction), 1 minute)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+    awsSample:
+      select: rate(sum(provider.invocations.Sum),1 minute)
+      from: ServerlessSample
+      where: provider='LambdaFunction'
+      eventId: entityGuid
+      eventName: entityName
 duration99PercentileS:
   title: Duration (99 percentile) (s)
-  query:
-    select: max(provider.duration.Maximum) / 1000
-    from: ServerlessSample
-    where: provider='LambdaFunction'
-    eventId: entityGuid
-    eventName: entityName
+  queries:
+    aws:
+      select: max(aws.lambda.Duration.byFunction) / 1000
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+    awsSample:
+      select: max(provider.duration.Maximum) / 1000
+      from: ServerlessSample
+      where: provider='LambdaFunction'
+      eventId: entityGuid
+      eventName: entityName
 throttles:
   title: Throttled invocations
-  query:
-    select: rate(sum(provider.throttles.Sum), 1 minute)
-    from: ServerlessSample
-    where: provider='LambdaFunction'
-    eventId: entityGuid
-    eventName: entityName
+  queries:
+    aws:
+      select: rate(sum(aws.lambda.Throttles.byFunction), 1 minute)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+    awsSample:
+      select: rate(sum(provider.throttles.Sum), 1 minute)
+      from: ServerlessSample
+      where: provider='LambdaFunction'
+      eventId: entityGuid
+      eventName: entityName

--- a/definitions/infra-awslambdafunctionalias/golden_metrics.yml
+++ b/definitions/infra-awslambdafunctionalias/golden_metrics.yml
@@ -1,32 +1,56 @@
 errorRate:
   title: Error rate %
-  query:
-    select: sum(provider.errors.Sum) * 100 / sum(provider.invocations.Sum)
-    from: ServerlessSample
-    where: provider='LambdaFunction'
-    eventId: entityGuid
-    eventName: entityName
+  queries:
+    aws:
+      select: sum(aws.lambda.Errors.byFunction) * 100 / sum(aws.lambda.Invocations.byFunction)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+    awsSample:
+      select: sum(provider.errors.Sum) * 100 / sum(provider.invocations.Sum)
+      from: ServerlessSample
+      where: provider='LambdaFunction'
+      eventId: entityGuid
+      eventName: entityName
 totalInvocations:
   title: Total Invocations
-  query:
-    select: rate(sum(provider.invocations.Sum),1 minute)
-    from: ServerlessSample
-    where: provider='LambdaFunction'
-    eventId: entityGuid
-    eventName: entityName
+  queries:
+    aws:
+      select: rate(sum(aws.lambda.Invocations.byFunction), 1 minute)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+    awsSample:
+      select: rate(sum(provider.invocations.Sum),1 minute)
+      from: ServerlessSample
+      where: provider='LambdaFunction'
+      eventId: entityGuid
+      eventName: entityName
 duration99PercentileS:
   title: Duration (99 percentile) (s)
-  query:
-    select: max(provider.duration.Maximum) / 1000
-    from: ServerlessSample
-    where: provider='LambdaFunction'
-    eventId: entityGuid
-    eventName: entityName
+  queries:
+    aws:
+      select: max(aws.lambda.Duration.byFunction) / 1000
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+    awsSample:
+      select: max(provider.duration.Maximum) / 1000
+      from: ServerlessSample
+      where: provider='LambdaFunction'
+      eventId: entityGuid
+      eventName: entityName
 throttles:
   title: Throttled invocations
-  query:
-    select: rate(sum(provider.throttles.Sum), 1 minute)
-    from: ServerlessSample
-    where: provider='LambdaFunction'
-    eventId: entityGuid
-    eventName: entityName
+  queries:
+    aws:
+      select: rate(sum(aws.lambda.Throttles.byFunction), 1 minute)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+    awsSample:
+      select: rate(sum(provider.throttles.Sum), 1 minute)
+      from: ServerlessSample
+      where: provider='LambdaFunction'
+      eventId: entityGuid
+      eventName: entityName

--- a/definitions/infra-awslambdaregion/golden_metrics.yml
+++ b/definitions/infra-awslambdaregion/golden_metrics.yml
@@ -1,16 +1,28 @@
 ConcurrentExecutions:
   title: Max Current Executions
-  query:
-    select: max(`provider.concurrentExecutions.Maximum`)
-    from: ServerlessSample
-    where: provider='LambdaRegion'
-    eventId: entityGuid
-    eventName: entityName
+  queries:
+    aws:
+      select: max(aws.lambda.ConcurrentExecutions.byFunction)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+    awsSample:
+      select: max(`provider.concurrentExecutions.Maximum`)
+      from: ServerlessSample
+      where: provider='LambdaRegion'
+      eventId: entityGuid
+      eventName: entityName
 UnreservedConcurrentExecutions:
   title: Max Unreserved Current Executions
-  query:
-    select: max(`provider.unreservedConcurrentExecutions.Maximum`)
-    from: ServerlessSample
-    where: provider='LambdaRegion'
-    eventId: entityGuid
-    eventName: entityName
+  queries:
+    aws:
+      select: max(aws.lambda.UnreservedConcurrentExecutions)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+    awsSample:
+      select: max(`provider.unreservedConcurrentExecutions.Maximum`)
+      from: ServerlessSample
+      where: provider='LambdaRegion'
+      eventId: entityGuid
+      eventName: entityName

--- a/definitions/infra-awsmediaconvertoperation/golden_metrics.yml
+++ b/definitions/infra-awsmediaconvertoperation/golden_metrics.yml
@@ -1,7 +1,7 @@
 operationErrors:
   title: Operation errors
   query:
-    select: average(errors)
+    select: average(provider.errors.Average)
     from: AwsMediaConvertOperationSample
     eventId: entityGuid
     eventName: entityName

--- a/definitions/infra-awsmediaconvertoperation/golden_metrics.yml
+++ b/definitions/infra-awsmediaconvertoperation/golden_metrics.yml
@@ -1,7 +1,13 @@
 operationErrors:
   title: Operation errors
-  query:
-    select: average(provider.errors.Average)
-    from: AwsMediaConvertOperationSample
-    eventId: entityGuid
-    eventName: entityName
+  queries:
+    aws:
+      select: average(aws.mediaconvert.Errors)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+    awsSample:
+      select: average(provider.errors.Average)
+      from: AwsMediaConvertOperationSample
+      eventId: entityGuid
+      eventName: entityName

--- a/definitions/infra-awsmediaconvertqueue/golden_metrics.yml
+++ b/definitions/infra-awsmediaconvertqueue/golden_metrics.yml
@@ -1,63 +1,63 @@
 audioOnlyOutputS:
   title: Audio-only output (s)
   query:
-    select: average(audioOutputDuration)
+    select: average(provider.audioOutputDuration.Average)
     from: AwsMediaConvertQueueSample
     eventId: entityGuid
     eventName: entityName
 standardDefinitionSdOutputS:
   title: Standard definition (SD) output (s)
   query:
-    select: average(sDOutputDuration)
+    select: average(provider.sDOutputDuration.Average)
     from: AwsMediaConvertQueueSample
     eventId: entityGuid
     eventName: entityName
 highDefinitionHdOutputS:
   title: High-definition (HD) output (s)
   query:
-    select: average(hDOutputDuration)
+    select: average(provider.hDOutputDuration.Average)
     from: AwsMediaConvertQueueSample
     eventId: entityGuid
     eventName: entityName
 ultraHighDefinitionUhdOutputS:
   title: Ultra-high-definition (UHD) output (s)
   query:
-    select: average(uHDOutputDuration)
+    select: average(provider.uHDOutputDuration.Average)
     from: AwsMediaConvertQueueSample
     eventId: entityGuid
     eventName: entityName
 8KOutputS:
   title: 8K output (s)
   query:
-    select: average(`8KOutputDuration`)
+    select: average(`provider.8KOutputDuration.Average`)
     from: AwsMediaConvertQueueSample
     eventId: entityGuid
     eventName: entityName
 jobsCompleted:
   title: Jobs completed
   query:
-    select: average(jobsCompletedCount)
+    select: average(provider.jobsCompletedCount.Average)
     from: AwsMediaConvertQueueSample
     eventId: entityGuid
     eventName: entityName
 jobsFailed:
   title: Jobs failed
   query:
-    select: average(jobsErroredCount)
+    select: average(provider.jobsErroredCount.Average)
     from: AwsMediaConvertQueueSample
     eventId: entityGuid
     eventName: entityName
 transcodingStandByDurationS:
   title: Transcoding stand by duration (s)
   query:
-    select: average(standbyTime)
+    select: average(provider.standbyTime.Average)
     from: AwsMediaConvertQueueSample
     eventId: entityGuid
     eventName: entityName
 transcodingDurationS:
   title: Transcoding duration (s)
   query:
-    select: average(transcodingTime)
+    select: average(provider.transcodingTime.Average)
     from: AwsMediaConvertQueueSample
     eventId: entityGuid
     eventName: entityName

--- a/definitions/infra-awsmediaconvertqueue/golden_metrics.yml
+++ b/definitions/infra-awsmediaconvertqueue/golden_metrics.yml
@@ -1,63 +1,117 @@
 audioOnlyOutputS:
   title: Audio-only output (s)
-  query:
-    select: average(provider.audioOutputDuration.Average)
-    from: AwsMediaConvertQueueSample
-    eventId: entityGuid
-    eventName: entityName
+  queries:
+    aws:
+      select: average(aws.mediaconvert.AudioOutputDuration)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+    awsSample:
+      select: average(provider.audioOutputDuration.Average)
+      from: AwsMediaConvertQueueSample
+      eventId: entityGuid
+      eventName: entityName
 standardDefinitionSdOutputS:
   title: Standard definition (SD) output (s)
-  query:
-    select: average(provider.sDOutputDuration.Average)
-    from: AwsMediaConvertQueueSample
-    eventId: entityGuid
-    eventName: entityName
+  queries:
+    aws:
+      select: average(aws.mediaconvert.SDOutputDuration)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+    awsSample:
+      select: average(provider.sDOutputDuration.Average)
+      from: AwsMediaConvertQueueSample
+      eventId: entityGuid
+      eventName: entityName
 highDefinitionHdOutputS:
   title: High-definition (HD) output (s)
-  query:
-    select: average(provider.hDOutputDuration.Average)
-    from: AwsMediaConvertQueueSample
-    eventId: entityGuid
-    eventName: entityName
+  queries:
+    aws:
+      select: average(aws.mediaconvert.HDOutputDuration)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+    awsSample:
+      select: average(provider.hDOutputDuration.Average)
+      from: AwsMediaConvertQueueSample
+      eventId: entityGuid
+      eventName: entityName
 ultraHighDefinitionUhdOutputS:
   title: Ultra-high-definition (UHD) output (s)
-  query:
-    select: average(provider.uHDOutputDuration.Average)
-    from: AwsMediaConvertQueueSample
-    eventId: entityGuid
-    eventName: entityName
+  queries:
+    aws:
+      select: average(aws.mediaconvert.UHDOutputDuration)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+    awsSample:
+      select: average(provider.uHDOutputDuration.Average)
+      from: AwsMediaConvertQueueSample
+      eventId: entityGuid
+      eventName: entityName
 8KOutputS:
   title: 8K output (s)
-  query:
-    select: average(`provider.8KOutputDuration.Average`)
-    from: AwsMediaConvertQueueSample
-    eventId: entityGuid
-    eventName: entityName
+  queries:
+    aws:
+      select: average(aws.mediaconvert.8KOutputDuration)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+    awsSample:
+      select: average(`provider.8KOutputDuration.Average`)
+      from: AwsMediaConvertQueueSample
+      eventId: entityGuid
+      eventName: entityName
 jobsCompleted:
   title: Jobs completed
-  query:
-    select: average(provider.jobsCompletedCount.Average)
-    from: AwsMediaConvertQueueSample
-    eventId: entityGuid
-    eventName: entityName
+  queries:
+    aws:
+      select: average(aws.mediaconvert.JobsCompletedCount)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+    awsSample:
+      select: average(provider.jobsCompletedCount.Average)
+      from: AwsMediaConvertQueueSample
+      eventId: entityGuid
+      eventName: entityName
 jobsFailed:
   title: Jobs failed
-  query:
-    select: average(provider.jobsErroredCount.Average)
-    from: AwsMediaConvertQueueSample
-    eventId: entityGuid
-    eventName: entityName
+  queries:
+    aws:
+      select: average(aws.mediaconvert.JobsErroredCount)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+    awsSample:
+      select: average(provider.jobsErroredCount.Average)
+      from: AwsMediaConvertQueueSample
+      eventId: entityGuid
+      eventName: entityName
 transcodingStandByDurationS:
   title: Transcoding stand by duration (s)
-  query:
-    select: average(provider.standbyTime.Average)
-    from: AwsMediaConvertQueueSample
-    eventId: entityGuid
-    eventName: entityName
+  queries:
+    aws:
+      select: average(aws.mediaconvert.StandbyTime)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+    awsSample:
+      select: average(provider.standbyTime.Average)
+      from: AwsMediaConvertQueueSample
+      eventId: entityGuid
+      eventName: entityName
 transcodingDurationS:
   title: Transcoding duration (s)
-  query:
-    select: average(provider.transcodingTime.Average)
-    from: AwsMediaConvertQueueSample
-    eventId: entityGuid
-    eventName: entityName
+  queries:
+    aws:
+      select: average(aws.mediaconvert.TranscodingTime)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+    awsSample:
+      select: average(provider.transcodingTime.Average)
+      from: AwsMediaConvertQueueSample
+      eventId: entityGuid
+      eventName: entityName

--- a/definitions/infra-awsmediaconvertqueue/golden_metrics.yml
+++ b/definitions/infra-awsmediaconvertqueue/golden_metrics.yml
@@ -54,7 +54,7 @@ ultraHighDefinitionUhdOutputS:
   title: 8K output (s)
   queries:
     aws:
-      select: average(aws.mediaconvert.8KOutputDuration)
+      select: average(`aws.mediaconvert.8KOutputDuration`)
       from: Metric
       eventId: entity.guid
       eventName: entity.name

--- a/definitions/infra-awsmediapackagevodpackagingconfiguration/golden_metrics.yml
+++ b/definitions/infra-awsmediapackagevodpackagingconfiguration/golden_metrics.yml
@@ -1,21 +1,39 @@
 bytesSuccessfullySentPerRequest:
   title: Bytes successfully sent per request
-  query:
-    select: average(provider.egressBytes.Average)
-    from: AwsMediaPackageVODPackagingConfigurationSample
-    eventId: entityGuid
-    eventName: entityName
+  queries:
+    aws:
+      select: average(aws.mediapackage.EgressBytes)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+    awsSample:
+      select: average(provider.egressBytes.Average)
+      from: AwsMediaPackageVODPackagingConfigurationSample
+      eventId: entityGuid
+      eventName: entityName
 processTimeOfOutputRequestsMs:
   title: Process time of output requests (ms)
-  query:
-    select: average(provider.egressResponseTime.Average)
-    from: AwsMediaPackageVODPackagingConfigurationSample
-    eventId: entityGuid
-    eventName: entityName
+  queries:
+    aws:
+      select: average(aws.mediapackage.EgressResponseTime)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+    awsSample:
+      select: average(provider.egressResponseTime.Average)
+      from: AwsMediaPackageVODPackagingConfigurationSample
+      eventId: entityGuid
+      eventName: entityName
 contentRequestsReceived:
   title: Content requests received
-  query:
-    select: sum(provider.egressRequestCount.Sum)
-    from: AwsMediaPackageVODPackagingConfigurationSample
-    eventId: entityGuid
-    eventName: entityName
+  queries:
+    aws:
+      select: sum(aws.mediapackage.EgressRequestCount)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+    awsSample:
+      select: sum(provider.egressRequestCount.Sum)
+      from: AwsMediaPackageVODPackagingConfigurationSample
+      eventId: entityGuid
+      eventName: entityName

--- a/definitions/infra-awsmediapackagevodpackagingconfiguration/golden_metrics.yml
+++ b/definitions/infra-awsmediapackagevodpackagingconfiguration/golden_metrics.yml
@@ -1,21 +1,21 @@
 bytesSuccessfullySentPerRequest:
   title: Bytes successfully sent per request
   query:
-    select: average(egressBytes)
+    select: average(provider.egressBytes.Average)
     from: AwsMediaPackageVODPackagingConfigurationSample
     eventId: entityGuid
     eventName: entityName
 processTimeOfOutputRequestsMs:
   title: Process time of output requests (ms)
   query:
-    select: average(egressResponseTime)
+    select: average(provider.egressResponseTime.Average)
     from: AwsMediaPackageVODPackagingConfigurationSample
     eventId: entityGuid
     eventName: entityName
 contentRequestsReceived:
   title: Content requests received
   query:
-    select: average(egressRequestCount)
+    select: sum(provider.egressRequestCount.Sum)
     from: AwsMediaPackageVODPackagingConfigurationSample
     eventId: entityGuid
     eventName: entityName

--- a/definitions/infra-awsmskbroker/golden_metrics.yml
+++ b/definitions/infra-awsmskbroker/golden_metrics.yml
@@ -1,24 +1,42 @@
 incomingMessagesPerSecond:
   title: Incoming Messages Per Second
-  query:
-    select: average(provider.messagesInPerSec.Average)
-    from: AwsMskBrokerSample
-    where: provider='AwsMskBroker'
-    eventId: entityGuid
-    eventName: entityName
+  queries:
+    aws:
+      select: average(aws.kafka.MessagesInPerSec.byBroker)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+    awsSample:
+      select: average(provider.messagesInPerSec.Average)
+      from: AwsMskBrokerSample
+      where: provider='AwsMskBroker'
+      eventId: entityGuid
+      eventName: entityName
 networkRxDropped:
   title: Network RX Dropped
-  query:
-    select: max(provider.networkRxDropped.Maximum)
-    from: AwsMskBrokerSample
-    where: provider='AwsMskBroker'
-    eventId: entityGuid
-    eventName: entityName
+  queries:
+    aws:
+      select: max(aws.kafka.NetworkRxDropped)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+    awsSample:
+      select: max(provider.networkRxDropped.Maximum)
+      from: AwsMskBrokerSample
+      where: provider='AwsMskBroker'
+      eventId: entityGuid
+      eventName: entityName
 networkTxDropped:
   title: Network TX Dropped
-  query:
-    select: max(provider.networkTxDropped.Maximum)
-    from: AwsMskBrokerSample
-    where: provider='AwsMskBroker'
-    eventId: entityGuid
-    eventName: entityName
+  queries:
+    aws:
+      select: max(aws.kafka.NetworkTxDropped)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+    awsSample:
+      select: max(provider.networkTxDropped.Maximum)
+      from: AwsMskBrokerSample
+      where: provider='AwsMskBroker'
+      eventId: entityGuid
+      eventName: entityName

--- a/definitions/infra-awsmskcluster/golden_metrics.yml
+++ b/definitions/infra-awsmskcluster/golden_metrics.yml
@@ -1,24 +1,42 @@
 activeControllers:
   title: Active controllers
-  query:
-    select: min(provider.activeControllerCount.Minimum)
-    from: AwsMskClusterSample
-    where: provider='AwsMskCluster'
-    eventId: entityGuid
-    eventName: entityName
+  queries:
+    aws:
+      select: min(aws.kafka.ActiveControllerCount)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+    awsSample:
+      select: min(provider.activeControllerCount.Minimum)
+      from: AwsMskClusterSample
+      where: provider='AwsMskCluster'
+      eventId: entityGuid
+      eventName: entityName
 globalPartitions:
   title: Global partitions
-  query:
-    select: min(provider.globalPartitionCount.Minimum)
-    from: AwsMskClusterSample
-    where: provider='AwsMskCluster'
-    eventId: entityGuid
-    eventName: entityName
+  queries:
+    aws:
+      select: min(aws.kafka.GlobalPartitionCount)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+    awsSample:
+      select: min(provider.globalPartitionCount.Minimum)
+      from: AwsMskClusterSample
+      where: provider='AwsMskCluster'
+      eventId: entityGuid
+      eventName: entityName
 offlinePartitions:
   title: Offline partitions
-  query:
-    select: max(provider.offlinePartitionsCount.Maximum)
-    from: AwsMskClusterSample
-    where: provider='AwsMskCluster'
-    eventId: entityGuid
-    eventName: entityName
+  queries:
+    aws:
+      select: max(aws.kafka.OfflinePartitionsCount)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+    awsSample:
+      select: max(provider.offlinePartitionsCount.Maximum)
+      from: AwsMskClusterSample
+      where: provider='AwsMskCluster'
+      eventId: entityGuid
+      eventName: entityName

--- a/definitions/infra-awsnlb/golden_metrics.yml
+++ b/definitions/infra-awsnlb/golden_metrics.yml
@@ -1,32 +1,56 @@
 failedClientNlbTlsHandshakes:
   title: Failed client-NLB TLS handshakes
-  query:
-    select: rate(sum(provider.clientTlsNegotiationErrorCount.Sum),1 minute)
-    from: LoadBalancerSample
-    where: provider='Nlb'
-    eventId: entityGuid
-    eventName: entityName
+  queries:
+    aws:
+      select: rate(sum(aws.applicationelb.ClientTLSNegotiationErrorCount), 1 minute)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+    awsSample:
+      select: rate(sum(provider.clientTlsNegotiationErrorCount.Sum),1 minute)
+      from: LoadBalancerSample
+      where: provider='Nlb'
+      eventId: entityGuid
+      eventName: entityName
 failedNlbTargetTlsHandshakes:
   title: Failed NLB-target TLS handshakes
-  query:
-    select: rate(sum(provider.targetTlsNegotiationErrorCount.Sum),1 minute)
-    from: LoadBalancerSample
-    where: provider='Nlb'
-    eventId: entityGuid
-    eventName: entityName
+  queries:
+    aws:
+      select: rate(sum(aws.applicationelb.TargetTLSNegotiationErrorCount), 1 minute)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+    awsSample:
+      select: rate(sum(provider.targetTlsNegotiationErrorCount.Sum),1 minute)
+      from: LoadBalancerSample
+      where: provider='Nlb'
+      eventId: entityGuid
+      eventName: entityName
 concurrentFlows:
   title: Avg Concurrent flows
-  query:
-    select: average(provider.activeFlowCount.Average)
-    from: LoadBalancerSample
-    where: provider='Nlb'
-    eventId: entityGuid
-    eventName: entityName
+  queries:
+    aws:
+      select: average(aws.networkelb.ActiveFlowCount)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+    awsSample:
+      select: average(provider.activeFlowCount.Average)
+      from: LoadBalancerSample
+      where: provider='Nlb'
+      eventId: entityGuid
+      eventName: entityName
 concurrentTlsFlows:
   title: Avg Concurrent TLS flows
-  query:
-    select: average(provider.activeFlowCountTls.Average)
-    from: LoadBalancerSample
-    where: provider='Nlb'
-    eventId: entityGuid
-    eventName: entityName
+  queries:
+    aws:
+      select: average(aws.networkelb.ActiveFlowCount_TLS)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+    awsSample:
+      select: average(provider.activeFlowCountTls.Average)
+      from: LoadBalancerSample
+      where: provider='Nlb'
+      eventId: entityGuid
+      eventName: entityName

--- a/definitions/infra-awsnlbtargetgroup/golden_metrics.yml
+++ b/definitions/infra-awsnlbtargetgroup/golden_metrics.yml
@@ -1,16 +1,28 @@
 unhealthyHosts:
   title: Unhealthy hosts
-  query:
-    select: max(provider.activeFlowCount.Maximum)
-    from: LoadBalancerSample
-    where: provider='NlbTargetGroup'
-    eventId: entityGuid
-    eventName: entityName
+  queries:
+    aws:
+      select: max(aws.networkelb.ActiveFlowCount)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+    awsSample:
+      select: max(provider.activeFlowCount.Maximum)
+      from: LoadBalancerSample
+      where: provider='NlbTargetGroup'
+      eventId: entityGuid
+      eventName: entityName
 healthyHosts:
   title: Healthy hosts
-  query:
-    select: min(provider.healthyHostCount.Minimum)
-    from: LoadBalancerSample
-    where: provider='NlbTargetGroup'
-    eventId: entityGuid
-    eventName: entityName
+  queries:
+    aws:
+      select: min(aws.elb.HealthyHostCount)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+    awsSample:
+      select: min(provider.healthyHostCount.Minimum)
+      from: LoadBalancerSample
+      where: provider='NlbTargetGroup'
+      eventId: entityGuid
+      eventName: entityName

--- a/definitions/infra-awsrdsdbcluster/golden_metrics.yml
+++ b/definitions/infra-awsrdsdbcluster/golden_metrics.yml
@@ -1,24 +1,42 @@
 readIops:
   title: Read IOPS
-  query:
-    select: average(provider.volumeReadIops.Average)
-    from: DatastoreSample
-    where: provider='RdsDbCluster'
-    eventId: entityGuid
-    eventName: entityName
+  queries:
+    aws:
+      select: average(aws.rds.VolumeReadIOPs.byDbCluster)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+    awsSample:
+      select: average(provider.volumeReadIops.Average)
+      from: DatastoreSample
+      where: provider='RdsDbCluster'
+      eventId: entityGuid
+      eventName: entityName
 writeIops:
   title: Write IOPS
-  query:
-    select: average(provider.volumeWriteIops.Average)
-    from: DatastoreSample
-    where: provider='RdsDbCluster'
-    eventId: entityGuid
-    eventName: entityName
+  queries:
+    aws:
+      select: average(aws.rds.VolumeWriteIOPs.byDbCluster)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+    awsSample:
+      select: average(provider.volumeWriteIops.Average)
+      from: DatastoreSample
+      where: provider='RdsDbCluster'
+      eventId: entityGuid
+      eventName: entityName
 usageBytes:
   title: Usage (bytes)
-  query:
-    select: average(provider.volumeUsedBytes.Average)
-    from: DatastoreSample
-    where: provider='RdsDbCluster'
-    eventId: entityGuid
-    eventName: entityName
+  queries:
+    aws:
+      select: average(aws.rds.VolumeBytesUsed.byDbCluster)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+    awsSample:
+      select: average(provider.volumeUsedBytes.Average)
+      from: DatastoreSample
+      where: provider='RdsDbCluster'
+      eventId: entityGuid
+      eventName: entityName

--- a/definitions/infra-awsrdsdbinstance/golden_metrics.yml
+++ b/definitions/infra-awsrdsdbinstance/golden_metrics.yml
@@ -1,32 +1,56 @@
 readThroughput:
   title: Read throughput
-  query:
-    select: average(provider.readThroughput.Average)
-    from: DatastoreSample
-    where: provider='RdsDbInstance'
-    eventId: entityGuid
-    eventName: entityName
+  queries:
+    aws:
+      select: average(aws.rds.ReadThroughput)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+    awsSample:
+      select: average(provider.readThroughput.Average)
+      from: DatastoreSample
+      where: provider='RdsDbInstance'
+      eventId: entityGuid
+      eventName: entityName
 writeThroughput:
   title: Write throughput
-  query:
-    select: average(provider.writeThroughput.Average)
-    from: DatastoreSample
-    where: provider='RdsDbInstance'
-    eventId: entityGuid
-    eventName: entityName
+  queries:
+    aws:
+      select: average(aws.rds.WriteThroughput)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+    awsSample:
+      select: average(provider.writeThroughput.Average)
+      from: DatastoreSample
+      where: provider='RdsDbInstance'
+      eventId: entityGuid
+      eventName: entityName
 latencyMs:
   title: Latency (ms)
-  query:
-    select: average(provider.readLatency.Average + provider.writeLatency.Average) * 1000
-    from: DatastoreSample
-    where: provider='RdsDbInstance'
-    eventId: entityGuid
-    eventName: entityName
+  queries:
+    aws:
+      select: (average(aws.rds.ReadLatency) + average(aws.rds.WriteLatency)) * 1000
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+    awsSample:
+      select: average(provider.readLatency.Average + provider.writeLatency.Average) * 1000
+      from: DatastoreSample
+      where: provider='RdsDbInstance'
+      eventId: entityGuid
+      eventName: entityName
 databaseConnections:
   title: Database connections
-  query:
-    select: average(provider.databaseConnections.Average)
-    from: DatastoreSample
-    where: provider='RdsDbInstance'
-    eventId: entityGuid
-    eventName: entityName
+  queries:
+    aws:
+      select: average(aws.rds.DatabaseConnections)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+    awsSample:
+      select: average(provider.databaseConnections.Average)
+      from: DatastoreSample
+      where: provider='RdsDbInstance'
+      eventId: entityGuid
+      eventName: entityName

--- a/definitions/infra-awsredshiftcluster/golden_metrics.yml
+++ b/definitions/infra-awsredshiftcluster/golden_metrics.yml
@@ -1,32 +1,56 @@
 CPUUtilization:
   title: Max CPU Utilization
-  query:
-    select: max(`provider.cpuUtilization.Maximum`)
-    from: DatastoreSample
-    where: provider='RedshiftCluster'
-    eventId: entityGuid
-    eventName: entityName
+  queries:
+    aws:
+      select: max(aws.rds.CPUUtilization)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+    awsSample:
+      select: max(`provider.cpuUtilization.Maximum`)
+      from: DatastoreSample
+      where: provider='RedshiftCluster'
+      eventId: entityGuid
+      eventName: entityName
 QueryDuration:
   title: Max Query Duration
-  query:
-    select: max(`provider.QueryDuration.Maximum`)
-    from: DatastoreSample
-    where: provider='RedshiftCluster'
-    eventId: entityGuid
-    eventName: entityName
+  queries:
+    aws:
+      select: max(aws.redshift.QueryDuration)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+    awsSample:
+      select: max(`provider.QueryDuration.Maximum`)
+      from: DatastoreSample
+      where: provider='RedshiftCluster'
+      eventId: entityGuid
+      eventName: entityName
 HealthStatus:
   title: Cluster Health Status
-  query:
-    select: min(`provider.HealthStatus.Minimum`)
-    from: DatastoreSample
-    where: provider='RedshiftCluster'
-    eventId: entityGuid
-    eventName: entityName
+  queries:
+    aws:
+      select: min(aws.redshift.HealthStatus.byCluster)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+    awsSample:
+      select: min(`provider.HealthStatus.Minimum`)
+      from: DatastoreSample
+      where: provider='RedshiftCluster'
+      eventId: entityGuid
+      eventName: entityName
 DatabaseConnections:
   title: Database Connections
-  query:
-    select: max(`provider.DatabaseConnections.Maximum`)
-    from: DatastoreSample
-    where: provider='RedshiftCluster'
-    eventId: entityGuid
-    eventName: entityName
+  queries:
+    aws:
+      select: max(aws.redshift.DatabaseConnections.byCluster)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+    awsSample:
+      select: max(`provider.DatabaseConnections.Maximum`)
+      from: DatastoreSample
+      where: provider='RedshiftCluster'
+      eventId: entityGuid
+      eventName: entityName

--- a/definitions/infra-awsredshiftnode/golden_metrics.yml
+++ b/definitions/infra-awsredshiftnode/golden_metrics.yml
@@ -1,48 +1,84 @@
 CPUUtilization:
   title: Max CPU Utilization
-  query:
-    select: max(`provider.cpuUtilization.Maximum`)
-    from: DatastoreSample
-    where: provider='RedshiftNode'
-    eventId: entityGuid
-    eventName: entityName
+  queries:
+    aws:
+      select: max(aws.rds.CPUUtilization)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+    awsSample:
+      select: max(`provider.cpuUtilization.Maximum`)
+      from: DatastoreSample
+      where: provider='RedshiftNode'
+      eventId: entityGuid
+      eventName: entityName
 DatabaseConnections:
   title: Database Connections
-  query:
-    select: max(`provider.DatabaseConnections.Maximum`)
-    from: DatastoreSample
-    where: provider='RedshiftNode'
-    eventId: entityGuid
-    eventName: entityName
+  queries:
+    aws:
+      select: max(aws.redshift.DatabaseConnections.byCluster)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+    awsSample:
+      select: max(`provider.DatabaseConnections.Maximum`)
+      from: DatastoreSample
+      where: provider='RedshiftNode'
+      eventId: entityGuid
+      eventName: entityName
 ReadLatency:
   title: Max Read Latency
-  query:
-    select: max(`provider.ReadLatency.Maximum`)
-    from: DatastoreSample
-    where: provider='RedshiftNode'
-    eventId: entityGuid
-    eventName: entityName
+  queries:
+    aws:
+      select: max(aws.es.ReadLatency)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+    awsSample:
+      select: max(`provider.ReadLatency.Maximum`)
+      from: DatastoreSample
+      where: provider='RedshiftNode'
+      eventId: entityGuid
+      eventName: entityName
 WriteLatency:
   title: Max Write Latency
-  query:
-    select: max(`provider.WriteLatency.Maximum`)
-    from: DatastoreSample
-    where: provider='RedshiftNode'
-    eventId: entityGuid
-    eventName: entityName
+  queries:
+    aws:
+      select: max(aws.es.WriteLatency)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+    awsSample:
+      select: max(`provider.WriteLatency.Maximum`)
+      from: DatastoreSample
+      where: provider='RedshiftNode'
+      eventId: entityGuid
+      eventName: entityName
 PercentageDiskSpace:
   title: Max Percentage disk space used
-  query:
-    select: max(`provider.PercentageDiskSpaceUsed.Maximum`)
-    from: DatastoreSample
-    where: provider='RedshiftNode'
-    eventId: entityGuid
-    eventName: entityName
+  queries:
+    aws:
+      select: max(aws.redshift.PercentageDiskSpaceUsed.byCluster)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+    awsSample:
+      select: max(`provider.PercentageDiskSpaceUsed.Maximum`)
+      from: DatastoreSample
+      where: provider='RedshiftNode'
+      eventId: entityGuid
+      eventName: entityName
 HealthStatus:
   title: Cluster Health Status
-  query:
-    select: min(`provider.HealthStatus.Minimum`)
-    from: DatastoreSample
-    where: provider='RedshiftNode'
-    eventId: entityGuid
-    eventName: entityName
+  queries:
+    aws:
+      select: min(aws.redshift.HealthStatus.byCluster)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+    awsSample:
+      select: min(`provider.HealthStatus.Minimum`)
+      from: DatastoreSample
+      where: provider='RedshiftNode'
+      eventId: entityGuid
+      eventName: entityName

--- a/definitions/infra-awss3bucket/golden_metrics.yml
+++ b/definitions/infra-awss3bucket/golden_metrics.yml
@@ -16,7 +16,7 @@ errors4xxAnd5xx:
   title: Errors
   queries:
     aws:
-      select: sum(aws.s3.4xxErrors) + sum(aws.s3.5xxErrors)
+      select: sum(`aws.s3.4xxErrors`) + sum(`aws.s3.5xxErrors`)
       from: Metric
       eventId: entity.guid
       eventName: entity.name

--- a/definitions/infra-awss3bucket/golden_metrics.yml
+++ b/definitions/infra-awss3bucket/golden_metrics.yml
@@ -1,41 +1,69 @@
 requests:
   title: Requests
-  query:
-    select: sum(`provider.getRequests.Sum`) + sum(`provider.putRequests.Sum`) + sum(`provider.headRequests.Sum`)
-    from: DatastoreSample
-    where: provider='S3BucketRequests'
-    eventId: entityGuid
-    eventName: entityName
-  unit: COUNT
+  queries:
+    aws:
+      select: sum(aws.s3.GetRequests) + sum(aws.s3.PutRequests) + sum(aws.s3.HeadRequests)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+    awsSample:
+      select: sum(`provider.getRequests.Sum`) + sum(`provider.putRequests.Sum`) + sum(`provider.headRequests.Sum`)
+      from: DatastoreSample
+      where: provider='S3BucketRequests'
+      eventId: entityGuid
+      eventName: entityName
 errors4xxAnd5xx:
   title: Errors
-  query:
-    select: sum(`provider.error4xxErrors.Sum`) + sum(`provider.error5xxErrors.Sum`)
-    from: DatastoreSample
-    eventId: entityGuid
-    where: provider='S3BucketRequests'
-    eventName: entityName
-  unit: COUNT
+  queries:
+    aws:
+      select: sum(aws.s3.4xxErrors) + sum(aws.s3.5xxErrors)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+    awsSample:
+      select: sum(`provider.error4xxErrors.Sum`) + sum(`provider.error5xxErrors.Sum`)
+      from: DatastoreSample
+      where: provider='S3BucketRequests'
+      eventId: entityGuid
+      eventName: entityName
 latency:
   title: Latency
-  query:
-    eventId: entityGuid
-    select: (average(`provider.totalRequestLatency.Average`)) / 1000
-    from: DatastoreSample
-  unit: SECONDS
+  queries:
+    aws:
+      select: (average(aws.s3.TotalRequestLatency)) / 1000
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+    awsSample:
+      select: (average(`provider.totalRequestLatency.Average`)) / 1000
+      from: DatastoreSample
+      eventId: entityGuid
+      eventName: entityName
 bytesDownloaded:
   title: Bytes downloaded
-  query:
-    select: sum(`provider.bytesDownloaded.Sum`)
-    from: DatastoreSample
-    where: provider='S3BucketRequests'
-    eventId: entityGuid
-    eventName: entityName
+  queries:
+    aws:
+      select: sum(aws.s3.BytesDownloaded)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+    awsSample:
+      select: sum(`provider.bytesDownloaded.Sum`)
+      from: DatastoreSample
+      where: provider='S3BucketRequests'
+      eventId: entityGuid
+      eventName: entityName
 bytesUploaded:
   title: Bytes uploaded
-  query:
-    select: sum(`provider.bytesUploaded.Sum`)
-    from: DatastoreSample
-    where: provider='S3BucketRequests'
-    eventId: entityGuid
-    eventName: entityName
+  queries:
+    aws:
+      select: sum(aws.s3.BytesUploaded)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+    awsSample:
+      select: sum(`provider.bytesUploaded.Sum`)
+      from: DatastoreSample
+      where: provider='S3BucketRequests'
+      eventId: entityGuid
+      eventName: entityName

--- a/definitions/infra-awssnstopic/golden_metrics.yml
+++ b/definitions/infra-awssnstopic/golden_metrics.yml
@@ -1,24 +1,42 @@
 publishedMessages:
   title: Published messages
-  query:
-    select: sum(provider.numberOfMessagesPublished.Sum)
-    from: QueueSample
-    where: provider='SnsTopic'
-    eventId: entityGuid
-    eventName: entityName
+  queries:
+    aws:
+      select: sum(aws.sns.NumberOfMessagesPublished)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+    awsSample:
+      select: sum(provider.numberOfMessagesPublished.Sum)
+      from: QueueSample
+      where: provider='SnsTopic'
+      eventId: entityGuid
+      eventName: entityName
 deliveredNotifications:
   title: Delivered notifications
-  query:
-    select: sum(provider.numberOfNotificationsDelivered.Sum)
-    from: QueueSample
-    where: provider='SnsTopic'
-    eventId: entityGuid
-    eventName: entityName
+  queries:
+    aws:
+      select: sum(aws.sns.NumberOfNotificationsDelivered)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+    awsSample:
+      select: sum(provider.numberOfNotificationsDelivered.Sum)
+      from: QueueSample
+      where: provider='SnsTopic'
+      eventId: entityGuid
+      eventName: entityName
 failedNotifications:
   title: Failed notifications
-  query:
-    select: sum(provider.numberOfNotificationsFailed.Sum)
-    from: QueueSample
-    where: provider='SnsTopic'
-    eventId: entityGuid
-    eventName: entityName
+  queries:
+    aws:
+      select: sum(aws.sns.NumberOfNotificationsFailed)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+    awsSample:
+      select: sum(provider.numberOfNotificationsFailed.Sum)
+      from: QueueSample
+      where: provider='SnsTopic'
+      eventId: entityGuid
+      eventName: entityName

--- a/definitions/infra-awssqsqueue/golden_metrics.yml
+++ b/definitions/infra-awssqsqueue/golden_metrics.yml
@@ -1,24 +1,42 @@
 receivedMessages:
   title: Received messages
-  query:
-    select: sum(provider.numberOfMessagesReceived.Sum)
-    from: QueueSample
-    where: provider='SqsQueue'
-    eventId: entityGuid
-    eventName: entityName
+  queries:
+    aws:
+      select: sum(aws.sqs.NumberOfMessagesReceived)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+    awsSample:
+      select: sum(provider.numberOfMessagesReceived.Sum)
+      from: QueueSample
+      where: provider='SqsQueue'
+      eventId: entityGuid
+      eventName: entityName
 sentMessages:
   title: Sent messages
-  query:
-    select: sum(provider.numberOfMessagesSent.Sum)
-    from: QueueSample
-    where: provider='SqsQueue'
-    eventId: entityGuid
-    eventName: entityName
+  queries:
+    aws:
+      select: sum(aws.sqs.NumberOfMessagesSent)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+    awsSample:
+      select: sum(provider.numberOfMessagesSent.Sum)
+      from: QueueSample
+      where: provider='SqsQueue'
+      eventId: entityGuid
+      eventName: entityName
 oldestMessageAgeS:
   title: Approximate age of oldest message (s)
-  query:
-    select: average(provider.approximateAgeOfOldestMessage.Average)
-    from: QueueSample
-    where: provider='SqsQueue'
-    eventId: entityGuid
-    eventName: entityName
+  queries:
+    aws:
+      select: average(aws.sqs.ApproximateAgeOfOldestMessage)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+    awsSample:
+      select: average(provider.approximateAgeOfOldestMessage.Average)
+      from: QueueSample
+      where: provider='SqsQueue'
+      eventId: entityGuid
+      eventName: entityName

--- a/definitions/infra-awsstatesstatemachine/golden_metrics.yml
+++ b/definitions/infra-awsstatesstatemachine/golden_metrics.yml
@@ -25,7 +25,7 @@ failedExecutions:
 errorRatio:
   title: Error ratio (%)
   query:
-    select: sum(`provider.executionsFailed.Sum`)/sum(`provider.executionsStarted.Sum`) * 100
+    select: sum(`provider.executionsFailed.Sum`) / sum(`provider.executionsStarted.Sum`) * 100
     from: AwsStatesStateMachineSample
     where: provider='AwsStatesStateMachine'
     eventId: entityGuid

--- a/definitions/infra-awsstatesstatemachine/golden_metrics.yml
+++ b/definitions/infra-awsstatesstatemachine/golden_metrics.yml
@@ -1,32 +1,56 @@
 successfulExecutions:
   title: Successful Executions
-  query:
-    select: sum(`provider.executionsSucceeded.Sum`)
-    from: AwsStatesStateMachineSample
-    where: provider='AwsStatesStateMachine'
-    eventId: entityGuid
-    eventName: entityName
+  queries:
+    aws:
+      select: sum(aws.states.ExecutionsSucceeded)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+    awsSample:
+      select: sum(`provider.executionsSucceeded.Sum`)
+      from: AwsStatesStateMachineSample
+      where: provider='AwsStatesStateMachine'
+      eventId: entityGuid
+      eventName: entityName
 executionTimeMs:
   title: Execution Time (ms)
-  query:
-    select: average(`provider.executionTime.Average`)
-    from: AwsStatesStateMachineSample
-    where: provider='AwsStatesStateMachine'
-    eventId: entityGuid
-    eventName: entityName
+  queries:
+    aws:
+      select: average(aws.states.ExecutionTime)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+    awsSample:
+      select: average(`provider.executionTime.Average`)
+      from: AwsStatesStateMachineSample
+      where: provider='AwsStatesStateMachine'
+      eventId: entityGuid
+      eventName: entityName
 failedExecutions:
   title: Failed Executions
-  query:
-    select: sum(`provider.executionsFailed.Sum`)
-    from: AwsStatesStateMachineSample
-    where: provider='AwsStatesStateMachine'
-    eventId: entityGuid
-    eventName: entityName
+  queries:
+    aws:
+      select: sum(aws.states.ExecutionsFailed)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+    awsSample:
+      select: sum(`provider.executionsFailed.Sum`)
+      from: AwsStatesStateMachineSample
+      where: provider='AwsStatesStateMachine'
+      eventId: entityGuid
+      eventName: entityName
 errorRatio:
   title: Error ratio (%)
-  query:
-    select: sum(`provider.executionsFailed.Sum`) / sum(`provider.executionsStarted.Sum`) * 100
-    from: AwsStatesStateMachineSample
-    where: provider='AwsStatesStateMachine'
-    eventId: entityGuid
-    eventName: entityName
+  queries:
+    aws:
+      select: sum(aws.states.ExecutionsFailed) / sum(aws.states.ExecutionsStarted) * 100
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+    awsSample:
+      select: sum(`provider.executionsFailed.Sum`) / sum(`provider.executionsStarted.Sum`) * 100
+      from: AwsStatesStateMachineSample
+      where: provider='AwsStatesStateMachine'
+      eventId: entityGuid
+      eventName: entityName


### PR DESCRIPTION
### Relevant information

Another attempt to fix AWS golden metrics. The backend services should now be able to handle the load. Let's merge this one and validate that it works in production - I'll then add the other ones (onhost, azure, gcp).

### Checklist

* [ ] I've read the guidelines and understand the acceptance criteria.
* [ ] The value of the attribute marked as `identifier` will be unique and valid. 
* [ ] I've confirmed that my entity type wasn't already defined. If it is I'm providing an
 explanation above.
