### PR TITLE
Remove instrumentation provider override for Kentik Router

### DIFF
--- a/definitions/ext-router/definition.yml
+++ b/definitions/ext-router/definition.yml
@@ -12,8 +12,7 @@ synthesis:
         - attribute: provider
           value: kentik-router
       tags:
-        provider:
-          entityTagName: instrumentation.provider
+        instrumentation.provider:
 
     # Mikrotik routers using Metric API
     - identifier: mikrotik.serialnumber


### PR DESCRIPTION
### Relevant information

Remove instrumentation provider override for Kentik Router, it was added by mistake ([reported](https://newrelic.slack.com/archives/C01CFRKGPMK/p1622667619119200?thread_ts=1622667288.118400&cid=C01CFRKGPMK))