### PR TITLE
feature: add summary metrics to synth private location

### DIFF
--- a/definitions/synth-private_location/definition.yml
+++ b/definitions/synth-private_location/definition.yml
@@ -3,3 +3,6 @@ type: PRIVATE_LOCATION
 configuration:
   entityExpirationTime: EIGHT_DAYS
   alertable: false
+compositeMetrics:
+  summaryMetrics:
+    - summary_metrics.yml

--- a/definitions/synth-private_location/summary_metrics.yml
+++ b/definitions/synth-private_location/summary_metrics.yml
@@ -1,0 +1,15 @@
+minions:
+  title: Minions
+  unit: COUNT
+  tag:
+    key: minionCount
+key:
+  title: Key
+  unit: STRING
+  tag:
+    key: key
+vse:
+  title: Verified Script Execution
+  unit: STRING
+  tag:
+    key: vse


### PR DESCRIPTION
### Relevant information

Adds summary metrics to synthetics private location entity.

### Checklist

* [ ] I've read the guidelines and understand the acceptance criteria.
* [ ] The value of the attribute marked as `identifier` will be unique and valid. 
* [ ] I've confirmed that my entity type wasn't already defined. If it is I'm providing an
 explanation above.
