### PR TITLE
Update TTL to 1 day + make VPCNETWORKINTERFACE alertable

### DIFF
--- a/definitions/infra-awsvpcnetworkinterface/definition.yml
+++ b/definitions/infra-awsvpcnetworkinterface/definition.yml
@@ -1,2 +1,5 @@
 domain: INFRA
 type: AWSVPCNETWORKINTERFACE
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true

--- a/definitions/infra-awsvpcvpntunnel/definition.yml
+++ b/definitions/infra-awsvpcvpntunnel/definition.yml
@@ -1,2 +1,4 @@
 domain: INFRA
 type: AWSVPCVPNTUNNEL
+configuration:
+  entityExpirationTime: DAILY


### PR DESCRIPTION
### Relevant information

It seems there is a misconfiguration from very old domain-types that should be 1 DAY, like rest of INFRA domain-types, this is confirmed by #beyond

Also, AWSVPCNETWORKINTERFACE do have metrics, so it can be potentially alertable.
