### PR TITLE
feat: adding ext-ups entity definition

### DIFF
--- a/definitions/ext-ups/dashboard.json
+++ b/definitions/ext-ups/dashboard.json
@@ -1,0 +1,196 @@
+{
+	"name": "Kentik - UPS",
+	"description": null,
+	"pages": [
+		{
+			"name": "Kentik - UPS",
+			"description": null,
+			"widgets": [
+				{
+					"visualization": {
+						"id": "viz.bar"
+					},
+					"layout": {
+						"column": 1,
+						"row": 1,
+						"height": 3,
+						"width": 4
+					},
+					"title": "Device Uptime (Hours)",
+					"rawConfiguration": {
+						"facet": {
+							"showOtherSeries": false
+						},
+						"nrqlQueries": [
+							{
+								"accountId": 0,
+								"query": "FROM Metric SELECT latest(`kentik.snmp.Uptime`)/100/60/60 AS 'Hours' FACET device_name WHERE provider = 'kentik-ups' LIMIT MAX"
+							}
+						]
+					}
+				},
+				{
+					"visualization": {
+						"id": "viz.bar"
+					},
+					"layout": {
+						"column": 5,
+						"row": 1,
+						"height": 3,
+						"width": 4
+					},
+					"title": "Time Currently Running on Battery (mins)",
+					"rawConfiguration": {
+						"facet": {
+							"showOtherSeries": false
+						},
+						"nrqlQueries": [
+							{
+								"accountId": 0,
+								"query": "FROM Metric SELECT latest(kentik.snmp.upsBasicBatteryTimeOnBattery)*.01/60 AS 'Time on Battery (mins)' FACET device_name WHERE provider = 'kentik-ups'"
+							}
+						]
+					}
+				},
+				{
+					"visualization": {
+						"id": "viz.bar"
+					},
+					"layout": {
+						"column": 9,
+						"row": 1,
+						"height": 3,
+						"width": 4
+					},
+					"title": "Battery Run Time Remaining (mins)",
+					"rawConfiguration": {
+						"facet": {
+							"showOtherSeries": false
+						},
+						"nrqlQueries": [
+							{
+								"accountId": 0,
+								"query": "FROM Metric SELECT latest(kentik.snmp.upsAdvBatteryRunTimeRemaining)*.01/60 AS 'Battery Run Time Remaining (mins)' FACET device_name WHERE provider = 'kentik-ups'"
+							}
+						]
+					}
+				},
+				{
+					"visualization": {
+						"id": "viz.line"
+					},
+					"layout": {
+						"column": 1,
+						"row": 4,
+						"height": 3,
+						"width": 4
+					},
+					"title": "Output Load Capacity %",
+					"rawConfiguration": {
+						"facet": {
+							"showOtherSeries": false
+						},
+						"legend": {
+							"enabled": true
+						},
+						"nrqlQueries": [
+							{
+								"accountId": 0,
+								"query": "FROM Metric SELECT latest(kentik.snmp.upsAdvOutputLoad) AS 'Output Load %' FACET device_name WHERE provider = 'kentik-ups' TIMESERIES 2 MINUTES"
+							}
+						],
+						"yAxisLeft": {
+							"max": 100,
+							"min": 0,
+							"zero": false
+						}
+					}
+				},
+				{
+					"visualization": {
+						"id": "viz.billboard"
+					},
+					"layout": {
+						"column": 5,
+						"row": 4,
+						"height": 3,
+						"width": 2
+					},
+					"title": "Battery Needs Replacing (1 == All Clear, 2 == Needs Replacing)",
+					"rawConfiguration": {
+						"dataFormatters": [],
+						"nrqlQueries": [
+							{
+								"accountId": 0,
+								"query": "FROM Metric SELECT latest(kentik.snmp.upsAdvBatteryReplaceIndicator) AS 'Battery Needs Replacing' FACET device_name WHERE provider = 'kentik-ups'"
+							}
+						],
+						"thresholds": [
+							{
+								"alertSeverity": "WARNING",
+								"value": 1.1
+							},
+							{
+								"alertSeverity": "CRITICAL",
+								"value": 1.9
+							}
+						]
+					}
+				},
+				{
+					"visualization": {
+						"id": "viz.billboard"
+					},
+					"layout": {
+						"column": 7,
+						"row": 4,
+						"height": 3,
+						"width": 2
+					},
+					"title": "Bad Battery Packs (Count)",
+					"rawConfiguration": {
+						"dataFormatters": [],
+						"nrqlQueries": [
+							{
+								"accountId": 0,
+								"query": "FROM Metric SELECT latest(kentik.snmp.upsAdvBatteryNumOfBadBattPacks) AS 'Bad Battery Packs' FACET device_name WHERE provider = 'kentik-ups'"
+							}
+						],
+						"thresholds": [
+							{
+								"alertSeverity": "WARNING",
+								"value": 0.5
+							},
+							{
+								"alertSeverity": "CRITICAL",
+								"value": 0.9
+							}
+						]
+					}
+				},
+				{
+					"visualization": {
+						"id": "viz.billboard"
+					},
+					"layout": {
+						"column": 9,
+						"row": 4,
+						"height": 3,
+						"width": 4
+					},
+					"title": "Battery Temperature",
+					"rawConfiguration": {
+						"dataFormatters": [],
+						"nrqlQueries": [
+							{
+								"accountId": 0,
+								"query": "FROM Metric SELECT latest(kentik.snmp.upsAdvBatteryTemperature) AS 'Celsius', (latest(kentik.snmp.upsAdvBatteryTemperature)*1.8) + 32 AS 'Fahrenheit' FACET device_name WHERE provider = 'kentik-ups'"
+							}
+						],
+						"thresholds": []
+					}
+				}
+			]
+		}
+	]
+}

--- a/definitions/ext-ups/definition.yml
+++ b/definitions/ext-ups/definition.yml
@@ -1,0 +1,27 @@
+domain: EXT
+type: UPS
+synthesis:
+  name: device_name
+  identifier: device_name
+  encodeIdentifierInGUID: true
+
+  conditions:
+  - attribute: provider
+    value: kentik-ups
+
+  tags:
+    src_addr:
+      entityTagName: device_ip
+
+compositeMetrics:
+  goldenMetrics:
+  - golden_metrics.yml
+  summaryMetrics:
+  - summary_metrics.yml
+
+goldenTags:
+- device_ip
+
+dashboardTemplates:
+  newRelic:
+    template: dashboard.json

--- a/definitions/ext-ups/golden_metrics.yml
+++ b/definitions/ext-ups/golden_metrics.yml
@@ -1,0 +1,20 @@
+outputLoadCapacity:
+  title: Output Load Capacity %
+  query:
+    select: average(kentik.snmp.upsAdvOutputLoad)
+    from: Metric
+    where: "provider = 'kentik-ups'"
+
+batteryTemperature:
+  title: Battery Temperature (Celsius)
+  query:
+    select: average(kentik.snmp.upsAdvBatteryTemperature)
+    from: Metric
+    where: "provider = 'kentik-ups'"
+
+batteryTimeRemaining:
+  title: Battery Run Time Remaining (mins)
+  query:
+    select: latest(kentik.snmp.upsAdvBatteryRunTimeRemaining)*.01/60
+    from: Metric
+    where: "provider = 'kentik-ups'"

--- a/definitions/ext-ups/summary_metrics.yml
+++ b/definitions/ext-ups/summary_metrics.yml
@@ -1,0 +1,32 @@
+ipAddress:
+  title: UPS IP Address
+  unit: STRING
+  tag:
+    key: device_ip
+
+outputLoadCapacity:
+  title: Load Capacity (%)
+  unit: PERCENTAGE
+  query:
+    select: latest(kentik.snmp.upsAdvOutputLoad)
+    from: Metric
+    where: "provider = 'kentik-ups'"
+    eventId: entity.guid
+
+batteryTemperature:
+  title: Battery Temp (C)
+  unit: STRING
+  query:
+    select: latest(kentik.snmp.upsAdvBatteryTemperature)
+    from: Metric
+    where: "provider = 'kentik-ups'"
+    eventId: entity.guid
+
+batteryTimeRemaining:
+  title: Battery Run Time Remaining
+  unit: SECONDS
+  query:
+    select: latest(kentik.snmp.upsAdvBatteryRunTimeRemaining)*.01
+    from: Metric
+    where: "provider = 'kentik-ups'"
+    eventId: entity.guid


### PR DESCRIPTION
### Relevant information

Adding definition for external UPS devices received from Kentik SNMP integration via Metrics API

### Checklist

* [x] I've read the guidelines and understand the acceptance criteria.
* [x] The value of the attribute marked as `identifier` will be unique and valid. 
* [x] I've confirmed that my entity type wasn't already defined. If it is I'm providing an
 explanation above.
