### PR TITLE
feat: adding ext-firewall entity definition

### DIFF
--- a/definitions/ext-firewall/dashboard.json
+++ b/definitions/ext-firewall/dashboard.json
@@ -1,0 +1,280 @@
+{
+	"name": "Kentik - Fortigate Firewall",
+	"description": null,
+	"pages": [
+		{
+			"name": "Kentik - Fortigate Firewall",
+			"description": null,
+			"widgets": [
+				{
+					"visualization": {
+						"id": "viz.line"
+					},
+					"layout": {
+						"column": 1,
+						"row": 1,
+						"height": 3,
+						"width": 4
+					},
+					"title": "CPU Utilization %",
+					"rawConfiguration": {
+						"facet": {
+							"showOtherSeries": false
+						},
+						"legend": {
+							"enabled": true
+						},
+						"nrqlQueries": [
+							{
+								"accountId": 0,
+								"query": "FROM Metric SELECT max(kentik.snmp.fgSysCpuUsage) AS 'CPU Utilization %' TIMESERIES "
+							}
+						],
+						"yAxisLeft": {
+							"max": 100,
+							"min": 0,
+							"zero": false
+						}
+					}
+				},
+				{
+					"visualization": {
+						"id": "viz.line"
+					},
+					"layout": {
+						"column": 5,
+						"row": 1,
+						"height": 3,
+						"width": 4
+					},
+					"title": "Memory Utilization %",
+					"rawConfiguration": {
+						"facet": {
+							"showOtherSeries": false
+						},
+						"legend": {
+							"enabled": true
+						},
+						"nrqlQueries": [
+							{
+								"accountId": 0,
+								"query": "FROM Metric SELECT (max(kentik.snmp.fgSysMemUsage) / max(kentik.snmp.fgSysMemCapacity)) * 100 AS 'Memory Utilization %' TIMESERIES "
+							}
+						],
+						"yAxisLeft": {
+							"max": 100,
+							"min": 0,
+							"zero": false
+						}
+					}
+				},
+				{
+					"visualization": {
+						"id": "viz.line"
+					},
+					"layout": {
+						"column": 9,
+						"row": 1,
+						"height": 3,
+						"width": 4
+					},
+					"title": "Disk Utilization %",
+					"rawConfiguration": {
+						"facet": {
+							"showOtherSeries": false
+						},
+						"legend": {
+							"enabled": true
+						},
+						"nrqlQueries": [
+							{
+								"accountId": 0,
+								"query": "FROM Metric SELECT (max(kentik.snmp.fgSysDiskUsage) / max(kentik.snmp.fgSysDiskCapacity)) * 100 AS 'Disk Utilization %' TIMESERIES "
+							}
+						],
+						"yAxisLeft": {
+							"max": 100,
+							"min": 0,
+							"zero": false
+						}
+					}
+				},
+				{
+					"visualization": {
+						"id": "viz.line"
+					},
+					"layout": {
+						"column": 1,
+						"row": 4,
+						"height": 3,
+						"width": 4
+					},
+					"title": "Lowmem Utilization %",
+					"rawConfiguration": {
+						"facet": {
+							"showOtherSeries": false
+						},
+						"legend": {
+							"enabled": true
+						},
+						"nrqlQueries": [
+							{
+								"accountId": 0,
+								"query": "FROM Metric SELECT (max(kentik.snmp.fgSysLowMemUsage) / max(kentik.snmp.fgSysLowMemCapacity)) * 100 AS 'Lowmem Utilization %' TIMESERIES "
+							}
+						],
+						"yAxisLeft": {
+							"max": 100,
+							"min": 0,
+							"zero": false
+						}
+					}
+				},
+				{
+					"visualization": {
+						"id": "viz.billboard"
+					},
+					"layout": {
+						"column": 5,
+						"row": 4,
+						"height": 3,
+						"width": 4
+					},
+					"title": "Current Sessions",
+					"rawConfiguration": {
+						"dataFormatters": [],
+						"nrqlQueries": [
+							{
+								"accountId": 0,
+								"query": "FROM Metric SELECT latest(kentik.snmp.fgSysSesCount) AS 'IPv4 Sessions', latest(kentik.snmp.fgSysSes6Count) AS 'IPv6 Sessions', latest(kentik.snmp.fgVdEntSesCount) AS 'Virtual Domain Sessions' "
+							}
+						],
+						"thresholds": []
+					}
+				},
+				{
+					"visualization": {
+						"id": "viz.line"
+					},
+					"layout": {
+						"column": 9,
+						"row": 4,
+						"height": 3,
+						"width": 4
+					},
+					"title": "Session 1min Rate",
+					"rawConfiguration": {
+						"facet": {
+							"showOtherSeries": false
+						},
+						"legend": {
+							"enabled": true
+						},
+						"nrqlQueries": [
+							{
+								"accountId": 0,
+								"query": "FROM Metric SELECT latest(kentik.snmp.fgSysSesRate1) AS 'IPv4 Sessions', latest(kentik.snmp.fgSysSes6Rate1) AS 'IPv6 Sessions', latest(kentik.snmp.fgVdEntSesRate) AS 'Virtual Domain Sessions' TIMESERIES"
+							}
+						],
+						"yAxisLeft": {
+							"zero": true
+						}
+					}
+				},
+				{
+					"visualization": {
+						"id": "viz.line"
+					},
+					"layout": {
+						"column": 1,
+						"row": 7,
+						"height": 3,
+						"width": 4
+					},
+					"title": "Virtual Domain CPU Utilization %",
+					"rawConfiguration": {
+						"facet": {
+							"showOtherSeries": false
+						},
+						"legend": {
+							"enabled": true
+						},
+						"nrqlQueries": [
+							{
+								"accountId": 0,
+								"query": "FROM Metric SELECT max(kentik.snmp.fgVdEntCpuUsage) AS 'Virtual Domain CPU Utilization %' TIMESERIES "
+							}
+						],
+						"yAxisLeft": {
+							"max": 100,
+							"min": 0,
+							"zero": false
+						}
+					}
+				},
+				{
+					"visualization": {
+						"id": "viz.line"
+					},
+					"layout": {
+						"column": 5,
+						"row": 7,
+						"height": 3,
+						"width": 4
+					},
+					"title": "Virtual Domain Memory Utilization %",
+					"rawConfiguration": {
+						"facet": {
+							"showOtherSeries": false
+						},
+						"legend": {
+							"enabled": true
+						},
+						"nrqlQueries": [
+							{
+								"accountId": 0,
+								"query": "FROM Metric SELECT max(kentik.snmp.fgVdEntMemUsage) AS 'Virtual Domain Memory Utilization %' TIMESERIES "
+							}
+						],
+						"yAxisLeft": {
+							"max": 100,
+							"min": 0,
+							"zero": false
+						}
+					}
+				},
+				{
+					"visualization": {
+						"id": "viz.line"
+					},
+					"layout": {
+						"column": 9,
+						"row": 7,
+						"height": 3,
+						"width": 4
+					},
+					"title": "Virtual Domains Utilization %",
+					"rawConfiguration": {
+						"facet": {
+							"showOtherSeries": false
+						},
+						"legend": {
+							"enabled": true
+						},
+						"nrqlQueries": [
+							{
+								"accountId": 0,
+								"query": "FROM Metric SELECT (max(kentik.snmp.fgVdNumber) / max(kentik.snmp.fgVdMaxVdoms)) * 100 AS 'Virtual Domains Utilization %' TIMESERIES "
+							}
+						],
+						"yAxisLeft": {
+							"max": 100,
+							"min": 0,
+							"zero": false
+						}
+					}
+				}
+			]
+		}
+	]
+}

--- a/definitions/ext-firewall/definition.yml
+++ b/definitions/ext-firewall/definition.yml
@@ -1,0 +1,30 @@
+domain: EXT
+# Firewall devices from Kentik using Metric API
+# Note this initial definition is limited to only Fortigate Firewalls using the FORTINET-FORTIGATE-MIB
+# Future firewall entities will need to be isolated in the definition
+type: FIREWALL
+synthesis:
+  name: device_name
+  identifier: device_name
+  encodeIdentifierInGUID: true
+
+  conditions:
+  - attribute: provider
+    value: kentik-firewall
+
+  tags:
+    src_addr:
+      entityTagName: device_ip
+
+compositeMetrics:
+  goldenMetrics:
+  - golden_metrics.yml
+  summaryMetrics:
+  - summary_metrics.yml
+
+goldenTags:
+- device_ip
+
+dashboardTemplates:
+  newRelic:
+    template: dashboard.json

--- a/definitions/ext-firewall/definition.yml
+++ b/definitions/ext-firewall/definition.yml
@@ -26,5 +26,5 @@ goldenTags:
 - device_ip
 
 dashboardTemplates:
-  newRelic:
+  kentik:
     template: dashboard.json

--- a/definitions/ext-firewall/golden_metrics.yml
+++ b/definitions/ext-firewall/golden_metrics.yml
@@ -1,0 +1,27 @@
+cpuUtilization:
+  title: CPU Utilization (%)
+  query:
+    select: max(kentik.snmp.fgSysCpuUsage)
+    from: Metric
+    where: "provider = 'kentik-firewall'"
+
+memoryUtilization:
+  title: Memory Utilization (%)
+  query:
+    select: (max(kentik.snmp.fgSysMemUsage) / max(kentik.snmp.fgSysMemCapacity)) * 100
+    from: Metric
+    where: "provider = 'kentik-firewall'"
+
+lowmemUtilization:
+  title: Lowmem Utilization (%)
+  query:
+    select: (max(kentik.snmp.fgSysLowMemUsage) / max(kentik.snmp.fgSysLowMemCapacity)) * 100
+    from: Metric
+    where: "provider = 'kentik-firewall'"
+
+ipSessionRate:
+  title: IP Session Rate (1min)
+  query:
+    select: latest(kentik.snmp.fgSysSesRate1) + latest(kentik.snmp.fgSysSes6Rate1)
+    from: Metric
+    where: "provider = 'kentik-firewall'"

--- a/definitions/ext-firewall/summary_metrics.yml
+++ b/definitions/ext-firewall/summary_metrics.yml
@@ -1,0 +1,32 @@
+ipAddress:
+  title: Firewall IP Address
+  unit: STRING
+  tag:
+    key: device_ip
+
+cpuUtilization:
+  title: CPU Utilization (%)
+  unit: PERCENTAGE
+  query:
+    select: max(kentik.snmp.fgSysCpuUsage)
+    from: Metric
+    where: "provider = 'kentik-firewall'"
+    eventId: entity.guid
+
+memoryUtilization:
+  title: Memory Utilization (%)
+  unit: PERCENTAGE
+  query:
+    select: (max(kentik.snmp.fgSysMemUsage) / max(kentik.snmp.fgSysMemCapacity)) * 100
+    from: Metric
+    where: "provider = 'kentik-firewall'"
+    eventId: entity.guid
+
+ipSessionsTotal:
+  title: Current IP Sessions
+  unit: COUNT
+  query:
+    select: latest(kentik.snmp.fgSysSesCount) + latest(kentik.snmp.fgSysSes6Count)
+    from: Metric
+    where: "provider = 'kentik-firewall'"
+    eventId: entity.guid


### PR DESCRIPTION
### Relevant information

Adding `ext-firewall` entity definition from Kentik SNMP integration using Metrics API. 

**NOTE: This definition would only apply to a single vendor's data (Fortigate); future vendors will need to be added as additional sources much like the `ext-router` definition has today**

### Checklist

* [x] I've read the guidelines and understand the acceptance criteria.
* [x] The value of the attribute marked as `identifier` will be unique and valid. 
* [x] I've confirmed that my entity type wasn't already defined. If it is I'm providing an
 explanation above.
