### PR TITLE
Revert ext-host rule and golden metric changes 

### DIFF
--- a/definitions/ext-host/definition.yml
+++ b/definitions/ext-host/definition.yml
@@ -3,19 +3,12 @@ type: HOST
 synthesis:
   rules:
     #telemetry from datadog agent
-  - identifier: host.name
-    name: host.name
-    encodeIdentifierInGUID: true
-    conditions:
-    - attribute: metricName
-      prefix: datadog.system.
-    # opentelemetry host data from opentelemetry-collector
-  - identifier: host.name
-    name: host.name
-    encodeIdentifierInGUID: true
-    conditions:
-    - attribute: metricName
-      prefix: system.
+    - identifier: host.name
+      name: host.name
+      encodeIdentifierInGUID: true
+      conditions:
+        - attribute: metricName
+          prefix: datadog.system.
 
 dashboardTemplates:
   newRelic:

--- a/definitions/infra-apacheserver/golden_metrics.yml
+++ b/definitions/infra-apacheserver/golden_metrics.yml
@@ -1,52 +1,28 @@
 requestsPerSecond:
   title: Requests per second
-  queries:
-    newRelic:
-      select: average(apache.server.net.requestsPerSecond)
-      from: Metric
-      eventId: entity.guid
-      eventName: entity.name
-    newRelicSample:
-      select: average(net.requestsPerSecond)
-      from: ApacheSample
-      eventId: entityGuid
-      eventName: entityName
+  query:
+    select: average(net.requestsPerSecond)
+    from: ApacheSample
+    eventId: entityGuid
+    eventName: entityName
 totalBytesSentPerSecond:
   title: Total Bytes Sent per second
-  queries:
-    newRelic:
-      select: average(apache.server.net.bytesPerSecond)
-      from: Metric
-      eventId: entity.guid
-      eventName: entity.name
-    newRelicSample:
-      select: average(net.bytesPerSecond)
-      from: ApacheSample
-      eventId: entityGuid
-      eventName: entityName
+  query:
+    select: average(net.bytesPerSecond)
+    from: ApacheSample
+    eventId: entityGuid
+    eventName: entityName
 busyWorkers:
   title: Current number of Busy Workers
-  queries:
-    newRelic:
-      select: average(apache.server.busyWorkers)
-      from: Metric
-      eventId: entity.guid
-      eventName: entity.name
-    newRelicSample:
-      select: average(server.busyWorkers)
-      from: ApacheSample
-      eventId: entityGuid
-      eventName: entityName
+  query:
+    select: average(server.busyWorkers)
+    from: ApacheSample
+    eventId: entityGuid
+    eventName: entityName
 idleWorkers:
   title: Current number of Idle Workers
-  queries:
-    newRelic:
-      select: average(apache.server.idleWorkers)
-      from: Metric
-      eventId: entity.guid
-      eventName: entity.name
-    newRelicSample:
-      select: average(server.idleWorkers)
-      from: ApacheSample
-      eventId: entityGuid
-      eventName: entityName
+  query:
+    select: average(server.idleWorkers)
+    from: ApacheSample
+    eventId: entityGuid
+    eventName: entityName

--- a/definitions/infra-cassandranode/golden_metrics.yml
+++ b/definitions/infra-cassandranode/golden_metrics.yml
@@ -1,56 +1,32 @@
 readRequestsPerSecond:
   title: Read requests per second
-  queries:
-    newRelic:
-      select: average(cassandra.node.query.readRequestsPerSecond)
-      from: Metric
-      eventId: entity.guid
-      eventName: entity.name
-    newRelicSample:
-      select: average(query.readRequestsPerSecond)
-      from: CassandraSample
-      eventId: entityGuid
-      eventName: entityName
+  query:
+    select: average(query.readRequestsPerSecond)
+    from: CassandraSample
+    eventId: entityGuid
+    eventName: entityName
 writeRequestsPerSecond:
   title: Write requests per second
-  queries:
-    newRelic:
-      select: average(cassandra.node.query.writeRequestsPerSecond)
-      from: Metric
-      eventId: entity.guid
-      eventName: entity.name
-    newRelicSample:
-      select: average(query.writeRequestsPerSecond)
-      from: CassandraSample
-      eventId: entityGuid
-      eventName: entityName
+  query:
+    select: average(query.writeRequestsPerSecond)
+    from: CassandraSample
+    eventId: entityGuid
+    eventName: entityName
 droppedMessagesPerSecond:
   title: Dropped messages per second
-  queries:
-    newRelic:
-      select: average(cassandra.node.droppedBatchRemoveMessagesPerSecond) + average(cassandra.node.droppedBatchStoreMessagesPerSecond) + average(cassandra.node.droppedCounterMutationMessagesPerSecond) +
-        average(cassandra.node.droppedHintMessagesPerSecond) + average(cassandra.node.droppedMutationMessagesPerSecond) + average(cassandra.node.droppedPagedRangeMessagesPerSecond) + average(cassandra.node.droppedRangeSliceMessagesPerSecond)
-        + average(cassandra.node.droppedReadMessagesPerSecond) + average(cassandra.node.droppedReadRepairMessagesPerSecond) + average(cassandra.node.droppedRequestResponseMessagesPerSecond) + average(cassandra.node.droppedTraceMessagesPerSecond)
-      from: Metric
-      eventId: entity.guid
-      eventName: entity.name
-    newRelicSample:
-      select: average((db.droppedBatchRemoveMessagesPerSecond OR 0) + (db.droppedBatchStoreMessagesPerSecond OR 0) + (db.droppedCounterMutationMessagesPerSecond OR 0) + (db.droppedHintMessagesPerSecond
-        OR 0) + (db.droppedMutationMessagesPerSecond OR 0) + (db.droppedPagedRangeMessagesPerSecond OR 0) + (db.droppedRangeSliceMessagesPerSecond OR 0) + (db.droppedReadMessagesPerSecond OR 0) + (db.droppedReadRepairMessagesPerSecond
-        OR 0) + (db.droppedRequestResponseMessagesPerSecond OR 0) + (db.droppedTraceMessagesPerSecond OR 0))
-      from: CassandraSample
-      eventId: entityGuid
-      eventName: entityName
+  query:
+    select: average((db.droppedBatchRemoveMessagesPerSecond OR 0)+(db.droppedBatchStoreMessagesPerSecond
+      OR 0)+(db.droppedCounterMutationMessagesPerSecond OR 0)+(db.droppedHintMessagesPerSecond OR 0)+(db.droppedMutationMessagesPerSecond
+      OR 0)+(db.droppedPagedRangeMessagesPerSecond OR 0)+(db.droppedRangeSliceMessagesPerSecond OR 0)+(db.droppedReadMessagesPerSecond
+      OR 0)+(db.droppedReadRepairMessagesPerSecond OR 0)+(db.droppedRequestResponseMessagesPerSecond OR
+      0)+(db.droppedTraceMessagesPerSecond OR 0))
+    from: CassandraSample
+    eventId: entityGuid
+    eventName: entityName
 readLatency99Percentile:
   title: Read Latency (99 percentile)
-  queries:
-    newRelic:
-      select: average(cassandra.node.query.readLatency99ThPercentileMilliseconds)
-      from: Metric
-      eventId: entity.guid
-      eventName: entity.name
-    newRelicSample:
-      select: average(query.readLatency99thPercentileMilliseconds)
-      from: CassandraSample
-      eventId: entityGuid
-      eventName: entityName
+  query:
+    select: average(query.readLatency99thPercentileMilliseconds)
+    from: CassandraSample
+    eventId: entityGuid
+    eventName: entityName

--- a/definitions/infra-elasticsearchnode/golden_metrics.yml
+++ b/definitions/infra-elasticsearchnode/golden_metrics.yml
@@ -1,39 +1,21 @@
 activeSearches:
   title: Active Searches
-  queries:
-    newRelic:
-      select: sum(elasticsearch.node.activeSearches)
-      from: Metric
-      eventId: entity.guid
-      eventName: entity.name
-    newRelicSample:
-      select: sum(activeSearches)
-      from: ElasticsearchNodeSample
-      eventId: entityGuid
-      eventName: entityName
+  query:
+    select: sum(activeSearches)
+    from: ElasticsearchNodeSample
+    eventId: entityGuid
+    eventName: entityName
 missingDocumentRequests:
   title: Missing Document Requests
-  queries:
-    newRelic:
-      select: sum(elasticsearch.node.get.requestsDocumentMissing)
-      from: Metric
-      eventId: entity.guid
-      eventName: entity.name
-    newRelicSample:
-      select: sum(get.requestsDocumentMissing)
-      from: ElasticsearchNodeSample
-      eventId: entityGuid
-      eventName: entityName
+  query:
+    select: sum(get.requestsDocumentMissing)
+    from: ElasticsearchNodeSample
+    eventId: entityGuid
+    eventName: entityName
 fileStoreIOOperations:
   title: File Store I/O Operations
-  queries:
-    newRelic:
-      select: sum(elasticsearch.node.fs.ioOperations)
-      from: Metric
-      eventId: entity.guid
-      eventName: entity.name
-    newRelicSample:
-      select: sum(fs.iOOperations)
-      from: ElasticsearchNodeSample
-      eventId: entityGuid
-      eventName: entityName
+  query:
+    select: sum(fs.iOOperations)
+    from: ElasticsearchNodeSample
+    eventId: entityGuid
+    eventName: entityName

--- a/definitions/infra-f5pool/golden_metrics.yml
+++ b/definitions/infra-f5pool/golden_metrics.yml
@@ -1,52 +1,28 @@
 requestsPerSecond:
   title: Requests per second
-  queries:
-    newRelic:
-      select: average(f5.pool.requestsPerSecond)
-      from: Metric
-      eventId: entity.guid
-      eventName: entity.name
-    newRelicSample:
-      select: average(pool.requestsPerSecond)
-      from: F5BigIpPoolSample
-      eventId: entityGuid
-      eventName: entityName
+  query:
+    select: average(pool.requestsPerSecond)
+    from: F5BigIpPoolSample
+    eventId: entityGuid
+    eventName: entityName
 connections:
   title: Connections
-  queries:
-    newRelic:
-      select: average(f5.pool.connections)
-      from: Metric
-      eventId: entity.guid
-      eventName: entity.name
-    newRelicSample:
-      select: average(pool.connections)
-      from: F5BigIpPoolSample
-      eventId: entityGuid
-      eventName: entityName
+  query:
+    select: average(pool.connections)
+    from: F5BigIpPoolSample
+    eventId: entityGuid
+    eventName: entityName
 packetsReceivedPerSecond:
   title: Packets received per second
-  queries:
-    newRelic:
-      select: average(f5.pool.packetsReceivedPerSecond)
-      from: Metric
-      eventId: entity.guid
-      eventName: entity.name
-    newRelicSample:
-      select: average(pool.packetsReceivedPerSecond)
-      from: F5BigIpPoolSample
-      eventId: entityGuid
-      eventName: entityName
+  query:
+    select: average(pool.packetsReceivedPerSecond)
+    from: F5BigIpPoolSample
+    eventId: entityGuid
+    eventName: entityName
 packetsSentPerSecond:
   title: Packets sent per second
-  queries:
-    newRelic:
-      select: average(f5.pool.packetsSentPerSecond)
-      from: Metric
-      eventId: entity.guid
-      eventName: entity.name
-    newRelicSample:
-      select: average(pool.packetsSentPerSecond)
-      from: F5BigIpPoolSample
-      eventId: entityGuid
-      eventName: entityName
+  query:
+    select: average(pool.packetsSentPerSecond)
+    from: F5BigIpPoolSample
+    eventId: entityGuid
+    eventName: entityName

--- a/definitions/infra-f5poolmember/golden_metrics.yml
+++ b/definitions/infra-f5poolmember/golden_metrics.yml
@@ -1,52 +1,28 @@
 connections:
   title: Connections
-  queries:
-    newRelic:
-      select: average(f5.poolMember.connections)
-      from: Metric
-      eventId: entity.guid
-      eventName: entity.name
-    newRelicSample:
-      select: average(member.connections)
-      from: F5BigIpPoolMemberSample
-      eventId: entityGuid
-      eventName: entityName
+  query:
+    select: average(member.connections)
+    from: F5BigIpPoolMemberSample
+    eventId: entityGuid
+    eventName: entityName
 sessions:
   title: Sessions
-  queries:
-    newRelic:
-      select: average(f5.poolMember.sessions)
-      from: Metric
-      eventId: entity.guid
-      eventName: entity.name
-    newRelicSample:
-      select: average(member.sessions)
-      from: F5BigIpPoolMemberSample
-      eventId: entityGuid
-      eventName: entityName
+  query:
+    select: average(member.sessions)
+    from: F5BigIpPoolMemberSample
+    eventId: entityGuid
+    eventName: entityName
 packetsReceivedPerSecond:
   title: Packets received per second
-  queries:
-    newRelic:
-      select: average(f5.poolMember.packetsReceivedPerSecond)
-      from: Metric
-      eventId: entity.guid
-      eventName: entity.name
-    newRelicSample:
-      select: average(member.packetsReceivedPerSecond)
-      from: F5BigIpPoolMemberSample
-      eventId: entityGuid
-      eventName: entityName
+  query:
+    select: average(member.packetsReceivedPerSecond)
+    from: F5BigIpPoolMemberSample
+    eventId: entityGuid
+    eventName: entityName
 packetsSentPerSecond:
   title: Packets sent per second
-  queries:
-    newRelic:
-      select: average(f5.poolMember.packetsSentPerSecond)
-      from: Metric
-      eventId: entity.guid
-      eventName: entity.name
-    newRelicSample:
-      select: average(member.packetsSentPerSecond)
-      from: F5BigIpPoolMemberSample
-      eventId: entityGuid
-      eventName: entityName
+  query:
+    select: average(member.packetsSentPerSecond)
+    from: F5BigIpPoolMemberSample
+    eventId: entityGuid
+    eventName: entityName

--- a/definitions/infra-f5virtualserver/golden_metrics.yml
+++ b/definitions/infra-f5virtualserver/golden_metrics.yml
@@ -1,52 +1,28 @@
 requestsPerSecond:
   title: Requests per second
-  queries:
-    newRelic:
-      select: average(f5.virtualserver.requestsPerSecond)
-      from: Metric
-      eventId: entity.guid
-      eventName: entity.name
-    newRelicSample:
-      select: average(virtualserver.requestsPerSecond)
-      from: F5BigIpVirtualServerSample
-      eventId: entityGuid
-      eventName: entityName
+  query:
+    select: average(virtualserver.requestsPerSecond)
+    from: F5BigIpVirtualServerSample
+    eventId: entityGuid
+    eventName: entityName
 connections:
   title: Connections
-  queries:
-    newRelic:
-      select: latest(f5.virtualserver.connections)
-      from: Metric
-      eventId: entity.guid
-      eventName: entity.name
-    newRelicSample:
-      select: latest(virtualserver.connections)
-      from: F5BigIpVirtualServerSample
-      eventId: entityGuid
-      eventName: entityName
+  query:
+    select: latest(virtualserver.connections)
+    from: F5BigIpVirtualServerSample
+    eventId: entityGuid
+    eventName: entityName
 bytesPerSecondIn:
   title: Bytes per second in
-  queries:
-    newRelic:
-      select: average(f5.virtualserver.inDataInBytesPerSecond)
-      from: Metric
-      eventId: entity.guid
-      eventName: entity.name
-    newRelicSample:
-      select: average(virtualserver.inDataInBytesPerSecond)
-      from: F5BigIpVirtualServerSample
-      eventId: entityGuid
-      eventName: entityName
+  query:
+    select: average(virtualserver.inDataInBytesPerSecond)
+    from: F5BigIpVirtualServerSample
+    eventId: entityGuid
+    eventName: entityName
 bytesPerSecondOut:
   title: Bytes per second out
-  queries:
-    newRelic:
-      select: average(f5.virtualserver.outDataInBytesPerSecond)
-      from: Metric
-      eventId: entity.guid
-      eventName: entity.name
-    newRelicSample:
-      select: average(virtualserver.outDataInBytesPerSecond)
-      from: F5BigIpVirtualServerSample
-      eventId: entityGuid
-      eventName: entityName
+  query:
+    select: average(virtualserver.outDataInBytesPerSecond)
+    from: F5BigIpVirtualServerSample
+    eventId: entityGuid
+    eventName: entityName

--- a/definitions/infra-host/golden_metrics.yml
+++ b/definitions/infra-host/golden_metrics.yml
@@ -1,52 +1,28 @@
 cpuUsage:
   title: CPU usage (%)
-  queries:
-    newRelic:
-      select: average(host.cpuPercent)
-      from: Metric
-      eventId: entity.guid
-      eventName: entity.name
-    newRelicSample:
-      select: average(cpuPercent)
-      from: SystemSample
-      eventId: entityGuid
-      eventName: entityName
+  query:
+    select: average(cpuPercent)
+    from: SystemSample
+    eventId: entityGuid
+    eventName: entityName
 memoryUsage:
   title: Memory usage (%)
-  queries:
-    newRelic:
-      select: average(host.memoryUsedPercent)
-      from: Metric
-      eventId: entity.guid
-      eventName: entity.name
-    newRelicSample:
-      select: average(memoryUsedPercent)
-      from: SystemSample
-      eventId: entityGuid
-      eventName: entityName
+  query:
+    select: average(memoryUsedPercent)
+    from: SystemSample
+    eventId: entityGuid
+    eventName: entityName
 storageUsage:
   title: Storage usage (%)
-  queries:
-    newRelic:
-      select: average(host.disk.usedPercent)
-      from: Metric
-      eventId: entity.guid
-      eventName: entity.name
-    newRelicSample:
-      select: average(diskUsedPercent)
-      from: StorageSample
-      eventId: entityGuid
-      eventName: entityName
+  query:
+    select: average(diskUsedPercent)
+    from: StorageSample
+    eventId: entityGuid
+    eventName: entityName
 networkTraffic:
   title: Network Traffic (kB/s)
-  queries:
-    newRelic:
-      select: average(host.net.transmitBytesPerSecond) + average(host.net.receiveBytesPerSecond)
-      from: Metric
-      eventId: entity.guid
-      eventName: entity.name
-    newRelicSample:
-      select: average(transmitBytesPerSecond) + average(receiveBytesPerSecond)
-      from: NetworkSample
-      eventId: entityGuid
-      eventName: entityName
+  query:
+    select: average(transmitBytesPerSecond) + average(receiveBytesPerSecond)
+    from: NetworkSample
+    eventId: entityGuid
+    eventName: entityName

--- a/definitions/infra-kafkabroker/golden_metrics.yml
+++ b/definitions/infra-kafkabroker/golden_metrics.yml
@@ -1,39 +1,21 @@
 incomingMessagesPerSecond:
   title: Incoming Messages Per Second
-  queries:
-    newRelic:
-      select: average(kafka.broker.messagesInPerSecond)
-      from: Metric
-      eventId: entity.guid
-      eventName: entity.name
-    newRelicSample:
-      select: average(broker.messagesInPerSecond)
-      from: KafkaBrokerSample
-      eventId: entityGuid
-      eventName: entityName
+  query:
+    select: average(broker.messagesInPerSecond)
+    from: KafkaBrokerSample
+    eventId: entityGuid
+    eventName: entityName
 produceRequestDuration99PercentileS:
   title: Produce Request Duration (99 percentile) (s)
-  queries:
-    newRelic:
-      select: average(kafka.broker.request.produceTime99Percentile)
-      from: Metric
-      eventId: entity.guid
-      eventName: entity.name
-    newRelicSample:
-      select: average(request.produceTime99Percentile)
-      from: KafkaBrokerSample
-      eventId: entityGuid
-      eventName: entityName
+  query:
+    select: average(request.produceTime99Percentile)
+    from: KafkaBrokerSample
+    eventId: entityGuid
+    eventName: entityName
 failedProduceRequestsPerSecond:
   title: Failed Produce Requests per Second
-  queries:
-    newRelic:
-      select: average(kafka.broker.request.produceRequestsFailedPerSecond)
-      from: Metric
-      eventId: entity.guid
-      eventName: entity.name
-    newRelicSample:
-      select: average(request.produceRequestsFailedPerSecond)
-      from: KafkaBrokerSample
-      eventId: entityGuid
-      eventName: entityName
+  query:
+    select: average(request.produceRequestsFailedPerSecond)
+    from: KafkaBrokerSample
+    eventId: entityGuid
+    eventName: entityName

--- a/definitions/infra-kubernetes_daemonset/golden_metrics.yml
+++ b/definitions/infra-kubernetes_daemonset/golden_metrics.yml
@@ -1,39 +1,21 @@
 podsDesired:
   title: Pods desired over time
-  queries:
-    newRelic:
-      select: latest(k8s.daemonset.podsDesired)
-      from: Metric
-      eventId: entity.guid
-      eventName: entity.name
-    newRelicSample:
-      select: latest(podsDesired)
-      from: K8sDaemonsetSample
-      eventId: entityGuid
-      eventName: entityName
+  query:
+    select: latest(podsDesired)
+    from: K8sDaemonsetSample
+    eventId: entityGuid
+    eventName: entityName
 podsReady:
   title: Pods ready over time
-  queries:
-    newRelic:
-      select: latest(k8s.daemonset.podsReady)
-      from: Metric
-      eventId: entity.guid
-      eventName: entity.name
-    newRelicSample:
-      select: latest(podsReady)
-      from: K8sDaemonsetSample
-      eventId: entityGuid
-      eventName: entityName
+  query:
+    select: latest(podsReady)
+    from: K8sDaemonsetSample
+    eventId: entityGuid
+    eventName: entityName
 podsMissing:
   title: Pods missing over time
-  queries:
-    newRelic:
-      select: latest(k8s.daemonset.podsMissing)
-      from: Metric
-      eventId: entity.guid
-      eventName: entity.name
-    newRelicSample:
-      select: latest(podsMissing)
-      from: K8sDaemonsetSample
-      eventId: entityGuid
-      eventName: entityName
+  query:
+    select: latest(podsMissing)
+    from: K8sDaemonsetSample
+    eventId: entityGuid
+    eventName: entityName

--- a/definitions/infra-kubernetes_deployment/golden_metrics.yml
+++ b/definitions/infra-kubernetes_deployment/golden_metrics.yml
@@ -1,39 +1,21 @@
 podsDesired:
   title: Pods desired over time
-  queries:
-    newRelic:
-      select: latest(k8s.deployment.podsDesired)
-      from: Metric
-      eventId: entity.guid
-      eventName: entity.name
-    newRelicSample:
-      select: latest(podsDesired)
-      from: K8sDeploymentSample
-      eventId: entityGuid
-      eventName: entityName
+  query:
+    select: latest(podsDesired)
+    from: K8sDeploymentSample
+    eventId: entityGuid
+    eventName: entityName
 podsAvailable:
   title: Pods available over time
-  queries:
-    newRelic:
-      select: latest(k8s.deployment.podsAvailable)
-      from: Metric
-      eventId: entity.guid
-      eventName: entity.name
-    newRelicSample:
-      select: latest(podsAvailable)
-      from: K8sDeploymentSample
-      eventId: entityGuid
-      eventName: entityName
+  query:
+    select: latest(podsAvailable)
+    from: K8sDeploymentSample
+    eventId: entityGuid
+    eventName: entityName
 podsMissing:
   title: Pods missing over time
-  queries:
-    newRelic:
-      select: latest(k8s.deployment.podsMissing)
-      from: Metric
-      eventId: entity.guid
-      eventName: entity.name
-    newRelicSample:
-      select: latest(podsMissing)
-      from: K8sDeploymentSample
-      eventId: entityGuid
-      eventName: entityName
+  query:
+    select: latest(podsMissing)
+    from: K8sDeploymentSample
+    eventId: entityGuid
+    eventName: entityName

--- a/definitions/infra-kubernetes_pod/golden_metrics.yml
+++ b/definitions/infra-kubernetes_pod/golden_metrics.yml
@@ -1,65 +1,41 @@
+statusOverTime:
+  title: Status changes over time
+  query:
+    select: count(*)
+    from: K8sPodSample
+    eventId: entityGuid
+    eventName: entityName
 podReadiness:
   title: Readiness over time
-  queries:
-    newRelic:
-      select: latest(k8s.pod.isReady)
-      from: Metric
-      eventId: entity.guid
-      eventName: entity.name
-    newRelicSample:
-      select: latest(isReady)
-      from: K8sPodSample
-      eventId: entityGuid
-      eventName: entityName
+  query:
+    select: latest(isReady)
+    from: K8sPodSample
+    eventId: entityGuid
+    eventName: entityName
 podScheduled:
   title: Scheduling status over time
-  queries:
-    newRelic:
-      select: latest(k8s.pod.isScheduled)
-      from: Metric
-      eventId: entity.guid
-      eventName: entity.name
-    newRelicSample:
-      select: latest(isScheduled)
-      from: K8sPodSample
-      eventId: entityGuid
-      eventName: entityName
+  query:
+    select: latest(isScheduled)
+    from: K8sPodSample
+    eventId: entityGuid
+    eventName: entityName
 networkErrors:
   title: Network errors (per second)
-  queries:
-    newRelic:
-      select: max(k8s.pod.netErrorsPerSecond)
-      from: Metric
-      eventId: entity.guid
-      eventName: entity.name
-    newRelicSample:
-      select: max(net.errorsPerSecond)
-      from: K8sPodSample
-      eventId: entityGuid
-      eventName: entityName
+  query:
+    select: max(net.errorsPerSecond)
+    from: K8sPodSample
+    eventId: entityGuid
 networkTxBytes:
   title: Network Tx (b/s)
-  queries:
-    newRelic:
-      select: max(k8s.pod.netTxBytesPerSecond)
-      from: Metric
-      eventId: entity.guid
-      eventName: entity.name
-    newRelicSample:
-      select: max(net.txBytesPerSecond)
-      from: K8sPodSample
-      eventId: entityGuid
-      eventName: entityName
+  query:
+    select: max(net.txBytesPerSecond)
+    from: K8sPodSample
+    eventId: entityGuid
+    eventName: entityName
 networkRxBytes:
   title: Network Rx (b/s)
-  queries:
-    newRelic:
-      select: max(k8s.pod.netRxBytesPerSecond)
-      from: Metric
-      eventId: entity.guid
-      eventName: entity.name
-    newRelicSample:
-      select: max(net.rxBytesPerSecond)
-      from: K8sPodSample
-      eventId: entityGuid
-      eventName: entityName
+  query:
+    select: max(net.rxBytesPerSecond)
+    from: K8sPodSample
+    eventId: entityGuid
+    eventName: entityName

--- a/definitions/infra-kubernetes_statefulset/golden_metrics.yml
+++ b/definitions/infra-kubernetes_statefulset/golden_metrics.yml
@@ -1,39 +1,21 @@
 podsDesired:
   title: Pods desired over time
-  queries:
-    newRelic:
-      select: latest(k8s.statefulset.podsDesired)
-      from: Metric
-      eventId: entity.guid
-      eventName: entity.name
-    newRelicSample:
-      select: latest(podsDesired)
-      from: K8sStatefulsetSample
-      eventId: entityGuid
-      eventName: entityName
+  query:
+    select: latest(podsDesired)
+    from: K8sStatefulsetSample
+    eventId: entityGuid
+    eventName: entityName
 podsReady:
   title: Pods ready over time
-  queries:
-    newRelic:
-      select: latest(k8s.statefulset.podsReady)
-      from: Metric
-      eventId: entity.guid
-      eventName: entity.name
-    newRelicSample:
-      select: latest(podsReady)
-      from: K8sStatefulsetSample
-      eventId: entityGuid
-      eventName: entityName
+  query:
+    select: latest(podsReady)
+    from: K8sStatefulsetSample
+    eventId: entityGuid
+    eventName: entityName
 podsMissing:
   title: Pods missing over time
-  queries:
-    newRelic:
-      select: latest(k8s.statefulset.podsMissing)
-      from: Metric
-      eventId: entity.guid
-      eventName: entity.name
-    newRelicSample:
-      select: latest(podsMissing)
-      from: K8sStatefulsetSample
-      eventId: entityGuid
-      eventName: entityName
+  query:
+    select: latest(podsMissing)
+    from: K8sStatefulsetSample
+    eventId: entityGuid
+    eventName: entityName

--- a/definitions/infra-mssqlinstance/golden_metrics.yml
+++ b/definitions/infra-mssqlinstance/golden_metrics.yml
@@ -1,39 +1,21 @@
 connections:
   title: Connections
-  queries:
-    newRelic:
-      select: average(mssql.instance.stats.connections)
-      from: Metric
-      eventId: entity.guid
-      eventName: entity.name
-    newRelicSample:
-      select: average(stats.connections)
-      from: MssqlInstanceSample
-      eventId: entityGuid
-      eventName: entityName
+  query:
+    select: average(stats.connections)
+    from: MssqlInstanceSample
+    eventId: entityGuid
+    eventName: entityName
 blockedProcesses:
   title: Blocked processes
-  queries:
-    newRelic:
-      select: max(mssql.instance.instance.blockedProcessesCount)
-      from: Metric
-      eventId: entity.guid
-      eventName: entity.name
-    newRelicSample:
-      select: max(instance.blockedProcessesCount)
-      from: MssqlInstanceSample
-      eventId: entityGuid
-      eventName: entityName
+  query:
+    select: max(instance.blockedProcessesCount)
+    from: MssqlInstanceSample
+    eventId: entityGuid
+    eventName: entityName
 waitTimeMs:
   title: Wait time (ms)
-  queries:
-    newRelic:
-      select: average(mssql.instance.system.waitTimeInMillisecondsPerSecond)
-      from: Metric
-      eventId: entity.guid
-      eventName: entity.name
-    newRelicSample:
-      select: average(system.waitTimeInMillisecondsPerSecond)
-      from: MssqlInstanceSample
-      eventId: entityGuid
-      eventName: entityName
+  query:
+    select: average(system.waitTimeInMillisecondsPerSecond)
+    from: MssqlInstanceSample
+    eventId: entityGuid
+    eventName: entityName

--- a/definitions/infra-mysqlnode/golden_metrics.yml
+++ b/definitions/infra-mysqlnode/golden_metrics.yml
@@ -1,39 +1,21 @@
 queriesPerSecond:
   title: Queries per second
-  queries:
-    newRelic:
-      select: average(mysql.node.query.queriesPerSecond)
-      from: Metric
-      eventId: entity.guid
-      eventName: entity.name
-    newRelicSample:
-      select: average(query.queriesPerSecond)
-      from: MysqlSample
-      eventId: entityGuid
-      eventName: entityName
+  query:
+    select: average(query.queriesPerSecond)
+    from: MysqlSample
+    eventId: entityGuid
+    eventName: entityName
 slowQueriesPerMinute:
   title: Slow queries per minute
-  queries:
-    newRelic:
-      select: average(mysql.node.query.slowQueriesPerSecond) * 60
-      from: Metric
-      eventId: entity.guid
-      eventName: entity.name
-    newRelicSample:
-      select: average(query.slowQueriesPerSecond) * 60
-      from: MysqlSample
-      eventId: entityGuid
-      eventName: entityName
+  query:
+    select: average(query.slowQueriesPerSecond) * 60
+    from: MysqlSample
+    eventId: entityGuid
+    eventName: entityName
 connectionsPerSecond:
   title: Connections per Second
-  queries:
-    newRelic:
-      select: average(mysql.node.net.connectionsPerSecond)
-      from: Metric
-      eventId: entity.guid
-      eventName: entity.name
-    newRelicSample:
-      select: average(net.connectionsPerSecond)
-      from: MysqlSample
-      eventId: entityGuid
-      eventName: entityName
+  query:
+    select: average(net.connectionsPerSecond)
+    from: MysqlSample
+    eventId: entityGuid
+    eventName: entityName

--- a/definitions/infra-nginxserver/golden_metrics.yml
+++ b/definitions/infra-nginxserver/golden_metrics.yml
@@ -1,26 +1,14 @@
 requests:
   title: Requests
-  queries:
-    newRelic:
-      select: average(nginx.server.net.requestsPerSecond)
-      from: Metric
-      eventId: entity.guid
-      eventName: entity.name
-    newRelicSample:
-      select: average(net.requestsPerSecond)
-      from: NginxSample
-      eventId: entityGuid
-      eventName: entityName
+  query:
+    select: average(net.requestsPerSecond)
+    from: NginxSample
+    eventId: entityGuid
+    eventName: entityName
 activeConnections:
   title: Active connections
-  queries:
-    newRelic:
-      select: average(nginx.server.net.connectionsActive)
-      from: Metric
-      eventId: entity.guid
-      eventName: entity.name
-    newRelicSample:
-      select: average(net.connectionsActive)
-      from: NginxSample
-      eventId: entityGuid
-      eventName: entityName
+  query:
+    select: average(net.connectionsActive)
+    from: NginxSample
+    eventId: entityGuid
+    eventName: entityName

--- a/definitions/infra-oracledbinstance/golden_metrics.yml
+++ b/definitions/infra-oracledbinstance/golden_metrics.yml
@@ -1,52 +1,28 @@
 hostCpuUtilization:
   title: Host CPU utilization
-  queries:
-    newRelic:
-      select: average(oracle.database.hostCpuUtilization)
-      from: Metric
-      eventId: entity.guid
-      eventName: entity.name
-    newRelicSample:
-      select: average(db.hostCpuUtilization)
-      from: OracleDatabaseSample
-      eventId: entityGuid
-      eventName: entityName
+  query:
+    select: average(db.hostCpuUtilization)
+    from: OracleDatabaseSample
+    eventId: entityGuid
+    eventName: entityName
 ioMegabytesPerSecond:
   title: IO Megabytes per Second
-  queries:
-    newRelic:
-      select: average(oracle.database.network.ioMegabytesPerSecond)
-      from: Metric
-      eventId: entity.guid
-      eventName: entity.name
-    newRelicSample:
-      select: average(network.ioMegabytesPerSecond)
-      from: OracleDatabaseSample
-      eventId: entityGuid
-      eventName: entityName
+  query:
+    select: average(network.ioMegabytesPerSecond)
+    from: OracleDatabaseSample
+    eventId: entityGuid
+    eventName: entityName
 sessions:
   title: Sessions
-  queries:
-    newRelic:
-      select: latest(oracle.database.sessionCount)
-      from: Metric
-      eventId: entity.guid
-      eventName: entity.name
-    newRelicSample:
-      select: latest(db.sessionCount)
-      from: OracleDatabaseSample
-      eventId: entityGuid
-      eventName: entityName
+  query:
+    select: latest(db.sessionCount)
+    from: OracleDatabaseSample
+    eventId: entityGuid
+    eventName: entityName
 executionsPerSecond:
   title: Executions per second
-  queries:
-    newRelic:
-      select: average(oracle.database.executionsPerSecond)
-      from: Metric
-      eventId: entity.guid
-      eventName: entity.name
-    newRelicSample:
-      select: average(db.executionsPerSecond)
-      from: OracleDatabaseSample
-      eventId: entityGuid
-      eventName: entityName
+  query:
+    select: average(db.executionsPerSecond)
+    from: OracleDatabaseSample
+    eventId: entityGuid
+    eventName: entityName

--- a/definitions/infra-postgresqlinstance/golden_metrics.yml
+++ b/definitions/infra-postgresqlinstance/golden_metrics.yml
@@ -1,39 +1,21 @@
 scheduledCheckpoints:
   title: Scheduled checkpoints
-  queries:
-    newRelic:
-      select: average(postgres.instance.bgwriter.checkpointsScheduledPerSecond)
-      from: Metric
-      eventId: entity.guid
-      eventName: entity.name
-    newRelicSample:
-      select: average(bgwriter.checkpointsScheduledPerSecond)
-      from: PostgresqlInstanceSample
-      eventId: entityGuid
-      eventName: entityName
+  query:
+    select: average(bgwriter.checkpointsScheduledPerSecond) as 'Scheduled checkpoints'
+    from: PostgresqlInstanceSample
+    eventId: entityGuid
+    eventName: entityName
 requestedCheckpoints:
   title: Requested checkpoints
-  queries:
-    newRelic:
-      select: average(postgres.instance.bgwriter.checkpointsRequestedPerSecond)
-      from: Metric
-      eventId: entity.guid
-      eventName: entity.name
-    newRelicSample:
-      select: average(bgwriter.checkpointsRequestedPerSecond)
-      from: PostgresqlInstanceSample
-      eventId: entityGuid
-      eventName: entityName
+  query:
+    select: average(bgwriter.checkpointsRequestedPerSecond) as 'Requested checkpoints'
+    from: PostgresqlInstanceSample
+    eventId: entityGuid
+    eventName: entityName
 buffersAllocated:
   title: Buffers allocated
-  queries:
-    newRelic:
-      select: average(postgres.instance.bgwriter.buffersAllocatedPerSecond)
-      from: Metric
-      eventId: entity.guid
-      eventName: entity.name
-    newRelicSample:
-      select: average(bgwriter.buffersAllocatedPerSecond)
-      from: PostgresqlInstanceSample
-      eventId: entityGuid
-      eventName: entityName
+  query:
+    select: average(bgwriter.buffersAllocatedPerSecond) as 'Buffers allocated'
+    from: PostgresqlInstanceSample
+    eventId: entityGuid
+    eventName: entityName

--- a/definitions/infra-rabbitmqexchange/golden_metrics.yml
+++ b/definitions/infra-rabbitmqexchange/golden_metrics.yml
@@ -1,65 +1,35 @@
 bindings:
   title: Bindings
-  queries:
-    newRelic:
-      select: average(rabbitmq.exchange.bindings)
-      from: Metric
-      eventId: entity.guid
-      eventName: entity.name
-    newRelicSample:
-      select: average(exchange.bindings)
-      from: RabbitmqExchangeSample
-      eventId: entityGuid
-      eventName: entityName
+  query:
+    select: average(exchange.bindings)
+    from: RabbitmqExchangeSample
+    eventId: entityGuid
+    eventName: entityName
 messagesPublishedPerChannel:
   title: Messages published per channel
-  queries:
-    newRelic:
-      select: sum(rabbitmq.exchange.messagesPublishedPerChannel)
-      from: Metric
-      eventId: entity.guid
-      eventName: entity.name
-    newRelicSample:
-      select: sum(exchange.messagesPublishedPerChannel)
-      from: RabbitmqExchangeSample
-      eventId: entityGuid
-      eventName: entityName
+  query:
+    select: sum(exchange.messagesPublishedPerChannel)
+    from: RabbitmqExchangeSample
+    eventId: entityGuid
+    eventName: entityName
 messagesPublishedPerChannelPerSecond:
   title: Messages published per channel per second
-  queries:
-    newRelic:
-      select: average(rabbitmq.exchange.messagesPublishedPerChannelPerSecond)
-      from: Metric
-      eventId: entity.guid
-      eventName: entity.name
-    newRelicSample:
-      select: average(exchange.messagesPublishedPerChannelPerSecond)
-      from: RabbitmqExchangeSample
-      eventId: entityGuid
-      eventName: entityName
+  query:
+    select: average(exchange.messagesPublishedPerChannelPerSecond)
+    from: RabbitmqExchangeSample
+    eventId: entityGuid
+    eventName: entityName
 messagesPublishedQueue:
   title: Messages published queue
-  queries:
-    newRelic:
-      select: sum(rabbitmq.exchange.messagesPublishedQueue)
-      from: Metric
-      eventId: entity.guid
-      eventName: entity.name
-    newRelicSample:
-      select: sum(exchange.messagesPublishedQueue)
-      from: RabbitmqExchangeSample
-      eventId: entityGuid
-      eventName: entityName
+  query:
+    select: sum(exchange.messagesPublishedQueue)
+    from: RabbitmqExchangeSample
+    eventId: entityGuid
+    eventName: entityName
 messagesPublishedQueuePerSecond:
   title: Messages published queue per second
-  queries:
-    newRelic:
-      select: average(rabbitmq.exchange.messagesPublishedQueuePerSecond)
-      from: Metric
-      eventId: entity.guid
-      eventName: entity.name
-    newRelicSample:
-      select: average(exchange.messagesPublishedQueuePerSecond)
-      from: RabbitmqExchangeSample
-      eventId: entityGuid
-      eventName: entityName
+  query:
+    select: average(exchange.messagesPublishedQueuePerSecond)
+    from: RabbitmqExchangeSample
+    eventId: entityGuid
+    eventName: entityName

--- a/definitions/infra-rabbitmqnode/golden_metrics.yml
+++ b/definitions/infra-rabbitmqnode/golden_metrics.yml
@@ -1,52 +1,28 @@
 totalMemoryUsedInBytes:
   title: Total memory used (bytes)
-  queries:
-    newRelic:
-      select: average(rabbitmq.node.totalMemoryUsedInBytes)
-      from: Metric
-      eventId: entity.guid
-      eventName: entity.name
-    newRelicSample:
-      select: average(node.totalMemoryUsedInBytes)
-      from: RabbitmqNodeSample
-      eventId: entityGuid
-      eventName: entityName
+  query:
+    select: average(node.totalMemoryUsedInBytes)
+    from: RabbitmqNodeSample
+    eventId: entityGuid
+    eventName: entityName
 diskSpaceFreeInBytes:
   title: Disk space free (bytes)
-  queries:
-    newRelic:
-      select: average(rabbitmq.node.diskSpaceFreeInBytes)
-      from: Metric
-      eventId: entity.guid
-      eventName: entity.name
-    newRelicSample:
-      select: average(node.diskSpaceFreeInBytes)
-      from: RabbitmqNodeSample
-      eventId: entityGuid
-      eventName: entityName
+  query:
+    select: average(node.diskSpaceFreeInBytes)
+    from: RabbitmqNodeSample
+    eventId: entityGuid
+    eventName: entityName
 fileDescriptorsTotalUsed:
   title: File descriptors total used
-  queries:
-    newRelic:
-      select: average(rabbitmq.node.fileDescriptorsTotalUsed)
-      from: Metric
-      eventId: entity.guid
-      eventName: entity.name
-    newRelicSample:
-      select: average(node.fileDescriptorsTotalUsed)
-      from: RabbitmqNodeSample
-      eventId: entityGuid
-      eventName: entityName
+  query:
+    select: average(node.fileDescriptorsTotalUsed)
+    from: RabbitmqNodeSample
+    eventId: entityGuid
+    eventName: entityName
 averageErlangProcessesWaiting:
   title: Average Erlang processes waiting
-  queries:
-    newRelic:
-      select: average(rabbitmq.node.averageErlangProcessesWaiting)
-      from: Metric
-      eventId: entity.guid
-      eventName: entity.name
-    newRelicSample:
-      select: average(node.averageErlangProcessesWaiting)
-      from: RabbitmqNodeSample
-      eventId: entityGuid
-      eventName: entityName
+  query:
+    select: average(node.averageErlangProcessesWaiting)
+    from: RabbitmqNodeSample
+    eventId: entityGuid
+    eventName: entityName

--- a/definitions/infra-rabbitmqqueue/golden_metrics.yml
+++ b/definitions/infra-rabbitmqqueue/golden_metrics.yml
@@ -1,65 +1,35 @@
 consumers:
   title: Consumers
-  queries:
-    newRelic:
-      select: average(rabbitmq.queue.consumers)
-      from: Metric
-      eventId: entity.guid
-      eventName: entity.name
-    newRelicSample:
-      select: average(queue.consumers)
-      from: RabbitmqQueueSample
-      eventId: entityGuid
-      eventName: entityName
+  query:
+    select: average(queue.consumers)
+    from: RabbitmqQueueSample
+    eventId: entityGuid
+    eventName: entityName
 messagesDelivered:
   title: Messages delivered
-  queries:
-    newRelic:
-      select: sum(rabbitmq.queue.sumMessagesDelivered)
-      from: Metric
-      eventId: entity.guid
-      eventName: entity.name
-    newRelicSample:
-      select: sum(queue.sumMessagesDelivered)
-      from: RabbitmqQueueSample
-      eventId: entityGuid
-      eventName: entityName
+  query:
+    select: sum(queue.sumMessagesDelivered)
+    from: RabbitmqQueueSample
+    eventId: entityGuid
+    eventName: entityName
 messagesDeliveredPerSecond:
   title: Messages delivered per second
-  queries:
-    newRelic:
-      select: average(rabbitmq.queue.sumMessagesDeliveredPerSecond)
-      from: Metric
-      eventId: entity.guid
-      eventName: entity.name
-    newRelicSample:
-      select: average(queue.sumMessagesDeliveredPerSecond)
-      from: RabbitmqQueueSample
-      eventId: entityGuid
-      eventName: entityName
+  query:
+    select: average(queue.sumMessagesDeliveredPerSecond)
+    from: RabbitmqQueueSample
+    eventId: entityGuid
+    eventName: entityName
 messagesPublished:
   title: Nessages published
-  queries:
-    newRelic:
-      select: sum(rabbitmq.queue.messagesPublished)
-      from: Metric
-      eventId: entity.guid
-      eventName: entity.name
-    newRelicSample:
-      select: sum(queue.messagesPublished)
-      from: RabbitmqQueueSample
-      eventId: entityGuid
-      eventName: entityName
+  query:
+    select: sum(queue.messagesPublished)
+    from: RabbitmqQueueSample
+    eventId: entityGuid
+    eventName: entityName
 messagesPublishedPerSecond:
   title: Messages published per second
-  queries:
-    newRelic:
-      select: average(rabbitmq.queue.messagesPublishedPerSecond)
-      from: Metric
-      eventId: entity.guid
-      eventName: entity.name
-    newRelicSample:
-      select: average(queue.messagesPublishedPerSecond)
-      from: RabbitmqQueueSample
-      eventId: entityGuid
-      eventName: entityName
+  query:
+    select: average(queue.messagesPublishedPerSecond)
+    from: RabbitmqQueueSample
+    eventId: entityGuid
+    eventName: entityName

--- a/definitions/infra-redisinstance/golden_metrics.yml
+++ b/definitions/infra-redisinstance/golden_metrics.yml
@@ -1,39 +1,21 @@
 keyspaceHitsPerSecond:
   title: Keyspace hits per second
-  queries:
-    newRelic:
-      select: average(redis.instance.keyspaceHitsPerSecond)
-      from: Metric
-      eventId: entity.guid
-      eventName: entity.name
-    newRelicSample:
-      select: average(db.keyspaceHitsPerSecond)
-      from: RedisSample
-      eventId: entityGuid
-      eventName: entityName
+  query:
+    select: average(db.keyspaceHitsPerSecond)
+    from: RedisSample
+    eventId: entityGuid
+    eventName: entityName
 keyspaceMissesPerSecond:
   title: Keyspace misses per second
-  queries:
-    newRelic:
-      select: average(redis.instance.keyspaceMissesPerSecond)
-      from: Metric
-      eventId: entity.guid
-      eventName: entity.name
-    newRelicSample:
-      select: average(db.keyspaceMissesPerSecond)
-      from: RedisSample
-      eventId: entityGuid
-      eventName: entityName
+  query:
+    select: average(db.keyspaceMissesPerSecond)
+    from: RedisSample
+    eventId: entityGuid
+    eventName: entityName
 connectedClients:
   title: Connected clients
-  queries:
-    newRelic:
-      select: average(redis.instance.net.connectedClients)
-      from: Metric
-      eventId: entity.guid
-      eventName: entity.name
-    newRelicSample:
-      select: average(net.connectedClients)
-      from: RedisSample
-      eventId: entityGuid
-      eventName: entityName
+  query:
+    select: average(net.connectedClients)
+    from: RedisSample
+    eventId: entityGuid
+    eventName: entityName

--- a/definitions/infra-vspherecluster/golden_metrics.yml
+++ b/definitions/infra-vspherecluster/golden_metrics.yml
@@ -1,39 +1,21 @@
 hostsCount:
   title: Total Hosts in the Cluster
-  queries:
-    newRelic:
-      select: latest(vsphere.cluster.hosts)
-      from: Metric
-      eventId: entity.guid
-      eventName: entity.name
-    newRelicSample:
-      select: latest(`hosts`)
-      from: VSphereClusterSample
-      eventId: entityGuid
-      eventName: entityName
+  query:
+    eventId: entityGuid
+    select: latest(`hosts`)
+    from: VSphereClusterSample
+    eventName: entityName
 totalEffectiveMHz:
   title: Total Effective CPU resources in MHz
-  queries:
-    newRelic:
-      select: latest(vsphere.cluster.cpu.totalEffectiveMHz)
-      from: Metric
-      eventId: entity.guid
-      eventName: entity.name
-    newRelicSample:
-      select: latest(`cpu.totalEffectiveMHz`)
-      from: VSphereClusterSample
-      eventId: entityGuid
-      eventName: entityName
+  query:
+    eventId: entityGuid
+    select: latest(`cpu.totalEffectiveMHz`)
+    from: VSphereClusterSample
+    eventName: entityName
 totalMHz:
   title: Aggregated CPU resources of all hosts in MHz
-  queries:
-    newRelic:
-      select: latest(vsphere.cluster.cpu.totalMhz)
-      from: Metric
-      eventId: entity.guid
-      eventName: entity.name
-    newRelicSample:
-      select: latest(`cpu.totalMHz`)
-      from: VSphereClusterSample
-      eventId: entityGuid
-      eventName: entityName
+  query:
+    eventId: entityGuid
+    select: latest(`cpu.totalMHz`)
+    from: VSphereClusterSample
+    eventName: entityName

--- a/definitions/infra-vspheredatacenter/golden_metrics.yml
+++ b/definitions/infra-vspheredatacenter/golden_metrics.yml
@@ -1,39 +1,21 @@
 cpuUsage:
   title: CPU Usage %
-  queries:
-    newRelic:
-      select: average(vsphere.datacenter.cpu.overallUsagePercentage)
-      from: Metric
-      eventId: entity.guid
-      eventName: entity.name
-    newRelicSample:
-      select: average(cpu.overallUsagePercentage)
-      from: VSphereDatacenterSample
-      eventId: entityGuid
-      eventName: entityName
+  query:
+    select: average(cpu.overallUsagePercentage)
+    from: VSphereDatacenterSample
+    eventId: entityGuid
+    eventName: entityName
 memoryUsage:
   title: Memory usage (%)
-  queries:
-    newRelic:
-      select: average(vsphere.datacenter.mem.usagePercentage)
-      from: Metric
-      eventId: entity.guid
-      eventName: entity.name
-    newRelicSample:
-      select: average(mem.usagePercentage)
-      from: VSphereDatacenterSample
-      eventId: entityGuid
-      eventName: entityName
+  query:
+    select: average(mem.usagePercentage)
+    from: VSphereDatacenterSample
+    eventId: entityGuid
+    eventName: entityName
 datastoreCapacityUtilizationGib:
   title: Datastore capacity utilization (GiB)
-  queries:
-    newRelic:
-      select: average(vsphere.datacenter.datastore.totalUsedGiB)
-      from: Metric
-      eventId: entity.guid
-      eventName: entity.name
-    newRelicSample:
-      select: average(datastore.totalUsedGiB)
-      from: VSphereDatacenterSample
-      eventId: entityGuid
-      eventName: entityName
+  query:
+    select: average(datastore.totalUsedGiB)
+    from: VSphereDatacenterSample
+    eventId: entityGuid
+    eventName: entityName

--- a/definitions/infra-vspheredatastore/golden_metrics.yml
+++ b/definitions/infra-vspheredatastore/golden_metrics.yml
@@ -1,26 +1,14 @@
 storageUsage:
   title: Storage usage (%)
-  queries:
-    newRelic:
-      select: average(vsphere.datastore.freeSpace) * 100 / average(vsphere.datastore.capacity)
-      from: Metric
-      eventId: entity.guid
-      eventName: entity.name
-    newRelicSample:
-      select: average(freeSpace) * 100 / average(capacity)
-      from: VSphereDatastoreSample
-      eventId: entityGuid
-      eventName: entityName
+  query:
+    select: average(freeSpace)*100/average(capacity)
+    from: VSphereDatastoreSample
+    eventId: entityGuid
+    eventName: entityName
 uncommittedSpaceGib:
   title: Uncommitted space (GiB)
-  queries:
-    newRelic:
-      select: average(vsphere.datastore.uncommitted)
-      from: Metric
-      eventId: entity.guid
-      eventName: entity.name
-    newRelicSample:
-      select: average(uncommitted)
-      from: VSphereDatastoreSample
-      eventId: entityGuid
-      eventName: entityName
+  query:
+    select: average(uncommitted)
+    from: VSphereDatastoreSample
+    eventId: entityGuid
+    eventName: entityName

--- a/definitions/infra-vspherehost/golden_metrics.yml
+++ b/definitions/infra-vspherehost/golden_metrics.yml
@@ -1,39 +1,21 @@
 cpuUsage:
   title: CPU usage (%)
-  queries:
-    newRelic:
-      select: average(vsphere.host.cpu.percent)
-      from: Metric
-      eventId: entity.guid
-      eventName: entity.name
-    newRelicSample:
-      select: average(cpu.percent)
-      from: VSphereHostSample
-      eventId: entityGuid
-      eventName: entityName
+  query:
+    select: average(cpu.percent)
+    from: VSphereHostSample
+    eventId: entityGuid
+    eventName: entityName
 memoryUsage:
   title: Memory usage (%)
-  queries:
-    newRelic:
-      select: average(vsphere.host.mem.free) * 100 / average(vsphere.host.mem.size)
-      from: Metric
-      eventId: entity.guid
-      eventName: entity.name
-    newRelicSample:
-      select: average(mem.free) * 100 / average(mem.size)
-      from: VSphereHostSample
-      eventId: entityGuid
-      eventName: entityName
+  query:
+    select: average(mem.free)*100/average(mem.size)
+    from: VSphereHostSample
+    eventId: entityGuid
+    eventName: entityName
 diskUsageMib:
   title: Disk usage (MiB)
-  queries:
-    newRelic:
-      select: average(vsphere.host.disk.totalMiB)
-      from: Metric
-      eventId: entity.guid
-      eventName: entity.name
-    newRelicSample:
-      select: average(disk.totalMiB)
-      from: VSphereHostSample
-      eventId: entityGuid
-      eventName: entityName
+  query:
+    select: average(disk.totalMiB)
+    from: VSphereHostSample
+    eventId: entityGuid
+    eventName: entityName

--- a/definitions/infra-vsphereresourcepool/golden_metrics.yml
+++ b/definitions/infra-vsphereresourcepool/golden_metrics.yml
@@ -1,39 +1,21 @@
 numberOfVmsInThisPool:
   title: Number of VMs in this pool
-  queries:
-    newRelic:
-      select: average(vsphere.resourcePool.vmCount)
-      from: Metric
-      eventId: entity.guid
-      eventName: entity.name
-    newRelicSample:
-      select: average(vmCount)
-      from: VSphereResourcePoolSample
-      eventId: entityGuid
-      eventName: entityName
+  query:
+    select: average(vmCount)
+    from: VSphereResourcePoolSample
+    eventId: entityGuid
+    eventName: entityName
 aggregatedCpuUsage:
   title: Aggregated CPU usage (%)
-  queries:
-    newRelic:
-      select: average(vsphere.resourcePool.cpu.overallUsage)
-      from: Metric
-      eventId: entity.guid
-      eventName: entity.name
-    newRelicSample:
-      select: average(cpu.overallUsage)
-      from: VSphereResourcePoolSample
-      eventId: entityGuid
-      eventName: entityName
+  query:
+    select: average(cpu.overallUsage)
+    from: VSphereResourcePoolSample
+    eventId: entityGuid
+    eventName: entityName
 aggregatedMemoryUsage:
   title: Aggregated memory usage (%)
-  queries:
-    newRelic:
-      select: average(vsphere.resourcePool.mem.usage) * 100 / (average(vsphere.resourcePool.mem.free) + average(vsphere.resourcePool.mem.usage))
-      from: Metric
-      eventId: entity.guid
-      eventName: entity.name
-    newRelicSample:
-      select: average(mem.usage) * 100 / (average(mem.free) + average(mem.usage))
-      from: VSphereResourcePoolSample
-      eventId: entityGuid
-      eventName: entityName
+  query:
+    select: average(mem.usage)*100/(average(mem.free)+average(mem.usage))
+    from: VSphereResourcePoolSample
+    eventId: entityGuid
+    eventName: entityName

--- a/definitions/infra-vspherevm/golden_metrics.yml
+++ b/definitions/infra-vspherevm/golden_metrics.yml
@@ -1,39 +1,21 @@
 cpuUsage:
   title: CPU usage (%)
-  queries:
-    newRelic:
-      select: average(vsphere.vm.cpu.hostUsagePercent)
-      from: Metric
-      eventId: entity.guid
-      eventName: entity.name
-    newRelicSample:
-      select: average(cpu.hostUsagePercent)
-      from: VSphereVmSample
-      eventId: entityGuid
-      eventName: entityName
+  query:
+    select: average(cpu.hostUsagePercent)
+    from: VSphereVmSample
+    eventId: entityGuid
+    eventName: entityName
 memoryUsage:
   title: Memory usage (%)
-  queries:
-    newRelic:
-      select: average(vsphere.vm.mem.usage) * 100 / average(vsphere.vm.mem.size)
-      from: Metric
-      eventId: entity.guid
-      eventName: entity.name
-    newRelicSample:
-      select: average(mem.usage) * 100 / average(mem.size)
-      from: VSphereVmSample
-      eventId: entityGuid
-      eventName: entityName
+  query:
+    select: average(mem.usage)*100/average(mem.size)
+    from: VSphereVmSample
+    eventId: entityGuid
+    eventName: entityName
 diskUsageMib:
   title: Disk usage (MiB)
-  queries:
-    newRelic:
-      select: average(vsphere.vm.disk.totalMiB)
-      from: Metric
-      eventId: entity.guid
-      eventName: entity.name
-    newRelicSample:
-      select: average(disk.totalMiB)
-      from: VSphereVmSample
-      eventId: entityGuid
-      eventName: entityName
+  query:
+    select: average(disk.totalMiB)
+    from: VSphereVmSample
+    eventId: entityGuid
+    eventName: entityName


### PR DESCRIPTION
### Relevant information

This reverts commit `f6362152360bf2ad0d3cced2e98d3a157e1232ae` and `a289bbf5bbbcc6ed1d4da6acd619d58d87d42ccc`. I'll really this last one after this PR is merged 

### Checklist

* [ ] I've read the guidelines and understand the acceptance criteria.
* [ ] The value of the attribute marked as `identifier` will be unique and valid. 
* [ ] I've confirmed that my entity type wasn't already defined. If it is I'm providing an
 explanation above.
