### PR TITLE
feat: adding ext-nas entity for netgear readynas

### DIFF
--- a/definitions/ext-nas/definition.yml
+++ b/definitions/ext-nas/definition.yml
@@ -1,0 +1,21 @@
+domain: EXT
+type: NAS
+synthesis:
+  name: device_name
+  identifier: device_name
+  encodeIdentifierInGUID: true
+
+  conditions:
+  - attribute: provider
+    value: kentik-nas
+
+  tags:
+    src_addr:
+      entityTagName: device_ip
+
+goldenTags:
+- device_ip
+
+dashboardTemplates:
+  kentik:
+    template: readynas-dashboard.json

--- a/definitions/ext-nas/golden_metrics.yml
+++ b/definitions/ext-nas/golden_metrics.yml
@@ -1,0 +1,14 @@
+# Tested on Netgear ReadyNAS
+cpuUtilization:
+  title: CPU Utilization (%)
+  query:
+    select: 100 - latest(kentik.snmp.ssCpuIdle)
+    from: Metric
+    where: "provider = 'kentik-nas' AND SysObjectID = '.1.3.6.1.4.1.4526.100.16'"
+
+memoryUtilization:
+  title: Memory Utilization (%)
+  query:
+    select: ((latest(kentik.snmp.memTotalReal) - latest(kentik.snmp.memAvailReal)) / latest(kentik.snmp.memTotalReal)) * 100
+    from: Metric
+    where: "provider = 'kentik-nas' AND SysObjectID = '.1.3.6.1.4.1.4526.100.16'"

--- a/definitions/ext-nas/readynas-dashboard.json
+++ b/definitions/ext-nas/readynas-dashboard.json
@@ -1,0 +1,246 @@
+{
+	"name": "Kentik - Netgear ReadyNAS",
+	"description": null,
+	"pages": [
+		{
+			"name": "Kentik - Netgear ReadyNAS",
+			"description": null,
+			"widgets": [
+				{
+					"visualization": {
+						"id": "viz.billboard"
+					},
+					"layout": {
+						"column": 1,
+						"row": 1,
+						"height": 3,
+						"width": 2
+					},
+					"title": "Device Uptime (Hours)",
+					"rawConfiguration": {
+						"dataFormatters": [
+							{
+								"name": "Hours",
+								"precision": null,
+								"type": "decimal"
+							}
+						],
+						"facet": {
+							"showOtherSeries": false
+						},
+						"nrqlQueries": [
+							{
+								"accountId": 0,
+								"query": "FROM Metric SELECT latest(`kentik.snmp.Uptime`)/100/60/60 AS 'Hours' FACET device_name WHERE provider = 'kentik-nas' AND SysObjectID = '.1.3.6.1.4.1.4526.100.16'"
+							}
+						],
+						"thresholds": []
+					}
+				},
+				{
+					"visualization": {
+						"id": "viz.billboard"
+					},
+					"layout": {
+						"column": 3,
+						"row": 1,
+						"height": 3,
+						"width": 2
+					},
+					"title": "Chassis Temperature",
+					"rawConfiguration": {
+						"dataFormatters": [],
+						"nrqlQueries": [
+							{
+								"accountId": 0,
+								"query": "FROM Metric SELECT latest(kentik.snmp.temperatureValue) AS 'Celsius', (latest(kentik.snmp.temperatureValue)*1.8) + 32 AS 'Fahrenheit' WHERE provider = 'kentik-nas' AND SysObjectID = '.1.3.6.1.4.1.4526.100.16'"
+							}
+						],
+						"thresholds": []
+					}
+				},
+				{
+					"visualization": {
+						"id": "viz.billboard"
+					},
+					"layout": {
+						"column": 5,
+						"row": 1,
+						"height": 3,
+						"width": 2
+					},
+					"title": "Power Supply Status",
+					"rawConfiguration": {
+						"dataFormatters": [],
+						"nrqlQueries": [
+							{
+								"accountId": 0,
+								"query": "FROM Metric SELECT latest(psuStatus) FACET psuDescription WHERE objectIdentifier = '1.3.6.1.4.1.4526.22.8.1.1' AND SysObjectID = '.1.3.6.1.4.1.4526.100.16'"
+							}
+						],
+						"thresholds": []
+					}
+				},
+				{
+					"visualization": {
+						"id": "viz.line"
+					},
+					"layout": {
+						"column": 7,
+						"row": 1,
+						"height": 3,
+						"width": 2
+					},
+					"title": "CPU Utilization %",
+					"rawConfiguration": {
+						"facet": {
+							"showOtherSeries": false
+						},
+						"legend": {
+							"enabled": true
+						},
+						"nrqlQueries": [
+							{
+								"accountId": 0,
+								"query": "FROM Metric SELECT 100 - latest(kentik.snmp.ssCpuIdle) FACET device_name WHERE provider = 'kentik-nas' AND SysObjectID = '.1.3.6.1.4.1.4526.100.16' TIMESERIES 2 MINUTES"
+							}
+						],
+						"yAxisLeft": {
+							"max": 100,
+							"min": 0,
+							"zero": true
+						}
+					}
+				},
+				{
+					"visualization": {
+						"id": "viz.line"
+					},
+					"layout": {
+						"column": 9,
+						"row": 1,
+						"height": 3,
+						"width": 2
+					},
+					"title": "Real Memory Utilization %",
+					"rawConfiguration": {
+						"facet": {
+							"showOtherSeries": false
+						},
+						"legend": {
+							"enabled": true
+						},
+						"nrqlQueries": [
+							{
+								"accountId": 0,
+								"query": "FROM Metric SELECT ((latest(kentik.snmp.memTotalReal) - latest(kentik.snmp.memAvailReal)) / latest(kentik.snmp.memTotalReal)) * 100 FACET device_name WHERE provider = 'kentik-nas' AND SysObjectID = '.1.3.6.1.4.1.4526.100.16' TIMESERIES 2 MINUTES"
+							}
+						],
+						"yAxisLeft": {
+							"zero": true
+						}
+					}
+				},
+				{
+					"visualization": {
+						"id": "viz.line"
+					},
+					"layout": {
+						"column": 11,
+						"row": 1,
+						"height": 3,
+						"width": 2
+					},
+					"title": "Swap Memory Utilization %",
+					"rawConfiguration": {
+						"facet": {
+							"showOtherSeries": false
+						},
+						"legend": {
+							"enabled": true
+						},
+						"nrqlQueries": [
+							{
+								"accountId": 0,
+								"query": "FROM Metric SELECT ((latest(kentik.snmp.memTotalSwap) - latest(kentik.snmp.memAvailSwap)) / latest(kentik.snmp.memTotalSwap)) * 100 FACET device_name WHERE provider = 'kentik-nas' AND SysObjectID = '.1.3.6.1.4.1.4526.100.16' TIMESERIES 2 MINUTES"
+							}
+						],
+						"yAxisLeft": {
+							"zero": true
+						}
+					}
+				},
+				{
+					"visualization": {
+						"id": "viz.table"
+					},
+					"layout": {
+						"column": 1,
+						"row": 4,
+						"height": 3,
+						"width": 6
+					},
+					"title": "NAS Volumes",
+					"rawConfiguration": {
+						"dataFormatters": [
+							{
+								"name": "Total GB",
+								"precision": null,
+								"type": "decimal"
+							},
+							{
+								"name": "Free GB",
+								"precision": null,
+								"type": "decimal"
+							},
+							{
+								"name": "% Utilization",
+								"precision": 2,
+								"type": "decimal"
+							}
+						],
+						"facet": {
+							"showOtherSeries": false
+						},
+						"nrqlQueries": [
+							{
+								"accountId": 0,
+								"query": "FROM Metric SELECT latest(kentik.snmp.volumeRAIDLevel) AS 'RAID', latest(kentik.snmp.volumeSize)/1024 AS 'Total GB', latest(kentik.snmp.volumeFreeSpace)/1024 AS 'Free GB', (latest(kentik.snmp.volumeSize) - latest(kentik.snmp.volumeFreeSpace)) / latest(kentik.snmp.volumeSize) *100 AS '% Utilization' FACET volumeName WHERE provider = 'kentik-nas' AND SysObjectID = '.1.3.6.1.4.1.4526.100.16'"
+							}
+						]
+					}
+				},
+				{
+					"visualization": {
+						"id": "viz.table"
+					},
+					"layout": {
+						"column": 7,
+						"row": 4,
+						"height": 3,
+						"width": 6
+					},
+					"title": "Disk Inventory",
+					"rawConfiguration": {
+						"dataFormatters": [
+							{
+								"name": "Capacity (GB)",
+								"precision": null,
+								"type": "decimal"
+							}
+						],
+						"facet": {
+							"showOtherSeries": false
+						},
+						"nrqlQueries": [
+							{
+								"accountId": 0,
+								"query": "FROM Metric SELECT latest(kentik.snmp.diskCapacity)/1073741824 AS 'Capacity (GB)' FACET diskID AS 'Name', diskModel AS 'Model', diskSerial AS 'Serial', diskState AS 'State', diskSlotName AS 'Slot Name', diskInterface AS 'Interface' WHERE provider = 'kentik-nas' AND SysObjectID = '.1.3.6.1.4.1.4526.100.16' LIMIT MAX"
+							}
+						]
+					}
+				}
+			]
+		}
+	]
+}

--- a/definitions/ext-nas/summary_metrics.yml
+++ b/definitions/ext-nas/summary_metrics.yml
@@ -1,0 +1,33 @@
+# Tested on Netgear ReadyNAS
+ipAddress:
+  title: IP Address
+  unit: STRING
+  tag:
+    key: device_ip
+
+model:
+  title: Model
+  unit: STRING
+  query:
+    select: latest(SysDescr)
+    from: Metric
+    where: "provider = 'kentik-nas' AND SysObjectID = '.1.3.6.1.4.1.4526.100.16'"
+    eventId: entity.guid
+
+cpuUtilization:
+  title: CPU Utilization (%)
+  unit: PERCENTAGE
+  query:
+    select: 100 - latest(kentik.snmp.ssCpuIdle)
+    from: Metric
+    where: "provider = 'kentik-nas' AND SysObjectID = '.1.3.6.1.4.1.4526.100.16'"
+    eventId: entity.guid
+
+memoryUtilization:
+  title: Memory Utilization (%)
+  unit: PERCENTAGE
+  query:
+    select: ((latest(kentik.snmp.memTotalReal) - latest(kentik.snmp.memAvailReal)) / latest(kentik.snmp.memTotalReal)) * 100
+    from: Metric
+    where: "provider = 'kentik-nas' AND SysObjectID = '.1.3.6.1.4.1.4526.100.16'"
+    eventId: entity.guid


### PR DESCRIPTION
### Relevant information

adding `ext-nas` entity type; tested on Netgear ReadyNAS device

**NOTE: This entity should end up in the `Other entities` section of the Explorer UI**

### Checklist

* [x] I've read the guidelines and understand the acceptance criteria.
* [x] The value of the attribute marked as `identifier` will be unique and valid. 
* [x] I've confirmed that my entity type wasn't already defined. If it is I'm providing an
 explanation above.
